### PR TITLE
Added Send + Sync to Model

### DIFF
--- a/crates/llm-base/src/model.rs
+++ b/crates/llm-base/src/model.rs
@@ -53,7 +53,7 @@ pub trait KnownModel: Send + Sync {
 
 /// A type-erased model to allow for interacting with a model without knowing
 /// its hyperparameters.
-pub trait Model {
+pub trait Model: Send + Sync {
     /// Starts a new `InferenceSession` for this model.
     fn start_session(&self, params: InferenceSessionParameters) -> InferenceSession;
 


### PR DESCRIPTION
As `KnownModel` implements `Send` and `Sync` and everything that implements `KnownModel` also implements `Model`, `Model` should also implement `Send` and `Sync`.