### PR TITLE
Speed up model loading

### DIFF
--- a/crates/llm-base/src/loader.rs
+++ b/crates/llm-base/src/loader.rs
@@ -352,12 +352,15 @@ pub fn load<M: KnownModel>(
     }
     impl TensorLoader<LoadError> for MmapCompatibleLoader<'_> {
         fn load(&mut self, name: &str) -> Result<ggml::Tensor, LoadError> {
-            let tensors = self.tensors.clone();
-            let info = tensors.get(name).ok_or(LoadError::UnknownTensor {
-                tensor_name: String::from(name),
-                path: Default::default(),
-            })?;
-            self.load_manual(&info.name, info.dims())
+            let tensor_dims = self
+                .tensors
+                .get(name)
+                .map(|tensor| tensor.dims().to_vec())
+                .ok_or(LoadError::UnknownTensor {
+                    tensor_name: String::from(name),
+                    path: Default::default(),
+                })?;
+            self.load_manual(name, &tensor_dims)
         }
 
         fn load_manual(&mut self, name: &str, ne: &[usize]) -> Result<ggml::Tensor, LoadError> {


### PR DESCRIPTION
We were previously cloning too much, causing even `mmap` file loads to be fairly slow.  After this patch, load times for alpaca-65b drop from 300ms minimum to ~6ms on my machine.  Similarly, I now get ~16s load times for `--no-mmap`.

I also snuck in a change to render the spinner less frequently, since `spinoff` apparently throws away spinner state on `update_text()` calls. I'm too lazy to make a second PR and that's arguably related to loading perf, so here it is.