### PR TITLE
fix #187 - skip over the BOS token for BLOOM

### DIFF
--- a/crates/llm-base/src/inference_session.rs
+++ b/crates/llm-base/src/inference_session.rs
@@ -93,10 +93,14 @@ impl InferenceSession {
         for batch in prompt_tokens.chunks(params.n_batch) {
             model.evaluate(self, params, batch, output_request);
             for &tk in batch {
-                // NOTE: No string ever tokenizes to the end of sentence. So we
-                // can just return the id here.
-                if let Err(e) = callback(vocab.token(tk as usize)) {
-                    return Err(InferenceError::UserCallback(Box::new(e)));
+                let should_call_callback = Some(tk) != model.bot_token_id();
+
+                if should_call_callback {
+                    // NOTE: No string ever tokenizes to the end of sentence. So we
+                    // can just return the id here.
+                    if let Err(e) = callback(vocab.token(tk as usize)) {
+                        return Err(InferenceError::UserCallback(Box::new(e)));
+                    }
                 }
 
                 // Update the tokens for this session

--- a/crates/llm-base/src/model/mod.rs
+++ b/crates/llm-base/src/model/mod.rs
@@ -54,7 +54,10 @@ pub trait KnownModel: Send + Sync {
     /// this model.
     fn n_context_tokens(&self) -> usize;
 
-    /// Get the end of text token ID. This value is defined by model implementers.
+    /// Get the beginning of text/beginning of string token ID, if available. This value is defined by model implementers.
+    fn bot_token_id(&self) -> Option<TokenId>;
+
+    /// Get the end of text/end of string token ID. This value is defined by model implementers.
     fn eot_token_id(&self) -> TokenId;
 
     /// Get the default [InferenceSessionParameters] for this model (used by
@@ -93,7 +96,10 @@ pub trait Model: Send + Sync {
     /// this model.
     fn n_context_tokens(&self) -> usize;
 
-    /// Get the end of text token ID. This value is defined by model implementers.
+    /// Get the beginning of text/beginning of string token ID, if available. This value is defined by model implementers.
+    fn bot_token_id(&self) -> Option<TokenId>;
+
+    /// Get the end of text/end of string token ID. This value is defined by model implementers.
     fn eot_token_id(&self) -> TokenId;
 
     /// Get the default [InferenceSessionParameters] for this model (used by
@@ -127,6 +133,10 @@ impl<H: Hyperparameters, M: KnownModel<Hyperparameters = H>> Model for M {
 
     fn n_context_tokens(&self) -> usize {
         KnownModel::n_context_tokens(self)
+    }
+
+    fn bot_token_id(&self) -> Option<TokenId> {
+        KnownModel::bot_token_id(self)
     }
 
     fn eot_token_id(&self) -> TokenId {

--- a/crates/models/bloom/src/lib.rs
+++ b/crates/models/bloom/src/lib.rs
@@ -410,6 +410,10 @@ impl KnownModel for Bloom {
         self.n_context_tokens
     }
 
+    fn bot_token_id(&self) -> Option<TokenId> {
+        self.vocabulary.token_to_id.get("<s>".as_bytes()).copied()
+    }
+
     fn eot_token_id(&self) -> TokenId {
         self.vocabulary
             .token_to_id

--- a/crates/models/gpt2/src/lib.rs
+++ b/crates/models/gpt2/src/lib.rs
@@ -330,6 +330,10 @@ impl KnownModel for Gpt2 {
         self.hyperparameters.n_ctx
     }
 
+    fn bot_token_id(&self) -> Option<TokenId> {
+        None
+    }
+
     fn eot_token_id(&self) -> TokenId {
         self.vocabulary
             .token_to_id

--- a/crates/models/gptj/src/lib.rs
+++ b/crates/models/gptj/src/lib.rs
@@ -322,6 +322,10 @@ impl KnownModel for GptJ {
         self.hyperparameters.n_ctx
     }
 
+    fn bot_token_id(&self) -> Option<TokenId> {
+        None
+    }
+
     fn eot_token_id(&self) -> TokenId {
         self.vocabulary
             .token_to_id

--- a/crates/models/llama/src/lib.rs
+++ b/crates/models/llama/src/lib.rs
@@ -357,6 +357,10 @@ impl KnownModel for Llama {
         self.n_context_tokens
     }
 
+    fn bot_token_id(&self) -> Option<TokenId> {
+        None
+    }
+
     fn eot_token_id(&self) -> TokenId {
         2
     }

--- a/crates/models/neox/src/lib.rs
+++ b/crates/models/neox/src/lib.rs
@@ -347,6 +347,10 @@ impl KnownModel for NeoX {
         self.hyperparameters.n_ctx
     }
 
+    fn bot_token_id(&self) -> Option<TokenId> {
+        None
+    }
+
     fn eot_token_id(&self) -> TokenId {
         self.vocabulary
             .token_to_id


### PR DESCRIPTION
This fixes the issue, but I'm still not sure if it's the *right* fix per se.