### PR TITLE
refactor: move load to KnownModel trait

### DIFF
--- a/crates/llm-base/src/model/mod.rs
+++ b/crates/llm-base/src/model/mod.rs
@@ -4,13 +4,14 @@ use std::{
     error::Error,
     fmt::Debug,
     io::{BufRead, Write},
+    path::Path,
 };
 
 use thiserror::Error;
 
 use crate::{
     loader::TensorLoader, vocabulary::TokenId, InferenceParameters, InferenceSession,
-    InferenceSessionConfig, LoadError, Vocabulary,
+    InferenceSessionConfig, LoadError, LoadProgress, Vocabulary,
 };
 
 /// Common functions for model evaluation
@@ -21,6 +22,20 @@ pub mod common;
 pub trait KnownModel: Send + Sync {
     /// Hyperparameters for the model
     type Hyperparameters: Hyperparameters;
+
+    /// Load this model from the `path` and configure it per the `params`. The status
+    /// of the loading process will be reported through `load_progress_callback`. This
+    /// is a helper function on top of [llm_base::load](crate::load).
+    fn load(
+        path: &Path,
+        params: ModelParameters,
+        load_progress_callback: impl FnMut(LoadProgress),
+    ) -> Result<Self, LoadError>
+    where
+        Self: Sized,
+    {
+        crate::load(path, params, load_progress_callback)
+    }
 
     /// Creates a new model from the provided [ModelParameters] hyperparameters.
     /// This function is called by the [load](crate::loader::load) function.

--- a/crates/models/bloom/src/lib.rs
+++ b/crates/models/bloom/src/lib.rs
@@ -2,13 +2,11 @@
 //! for the `llm` ecosystem.
 #![deny(missing_docs)]
 
-use std::path::Path;
-
 use llm_base::{
     ggml,
     model::{common, HyperparametersWriteError},
     util, FileType, InferenceParameters, InferenceSession, InferenceSessionConfig, KnownModel,
-    LoadError, LoadProgress, Mmap, ModelParameters, OutputRequest, TokenId, Vocabulary,
+    LoadError, Mmap, ModelParameters, OutputRequest, TokenId, Vocabulary,
 };
 
 /// The BLOOM model. Ref: [Introducing BLOOM](https://bigscience.huggingface.co/blog/bloom)
@@ -34,22 +32,8 @@ pub struct Bloom {
     _context: ggml::Context,
     _mmap: Option<Mmap>,
 }
-
 unsafe impl Send for Bloom {}
 unsafe impl Sync for Bloom {}
-
-impl Bloom {
-    /// Load a BLOOM model from the `path` and configure it per the `params`. The status
-    /// of the loading process will be reported through `load_progress_callback`. This
-    /// is a helper function on top of [llm_base::load].
-    pub fn load(
-        path: &Path,
-        params: ModelParameters,
-        load_progress_callback: impl FnMut(LoadProgress),
-    ) -> Result<Bloom, LoadError> {
-        llm_base::load(path, params, load_progress_callback)
-    }
-}
 
 impl KnownModel for Bloom {
     type Hyperparameters = Hyperparameters;

--- a/crates/models/gpt2/src/lib.rs
+++ b/crates/models/gpt2/src/lib.rs
@@ -1,14 +1,12 @@
 //! An implementation of [GPT-2](https://huggingface.co/docs/transformers/model_doc/gpt2) for the `llm` ecosystem.
 #![deny(missing_docs)]
 
-use std::path::Path;
-
 use ggml::Tensor;
 use llm_base::{
     ggml,
     model::{common, HyperparametersWriteError},
     util, FileType, InferenceParameters, InferenceSession, InferenceSessionConfig, KnownModel,
-    LoadError, LoadProgress, ModelParameters, OutputRequest, TokenId, Vocabulary,
+    LoadError, ModelParameters, OutputRequest, TokenId, Vocabulary,
 };
 
 /// The GPT-2 model. Ref: [The Illustrated GPT-2](https://jalammar.github.io/illustrated-gpt2/)
@@ -28,22 +26,8 @@ pub struct Gpt2 {
     inference_params: InferenceParameters,
     _context: ggml::Context,
 }
-
 unsafe impl Send for Gpt2 {}
 unsafe impl Sync for Gpt2 {}
-
-impl Gpt2 {
-    /// Load a GPT-2 model from the `path` and configure it per the `params`. The status
-    /// of the loading process will be reported through `load_progress_callback`. This
-    /// is a helper function on top of [llm_base::load].
-    pub fn load(
-        path: &Path,
-        params: ModelParameters,
-        load_progress_callback: impl FnMut(LoadProgress),
-    ) -> Result<Gpt2, LoadError> {
-        llm_base::load(path, params, load_progress_callback)
-    }
-}
 
 impl KnownModel for Gpt2 {
     type Hyperparameters = Hyperparameters;

--- a/crates/models/gptj/src/lib.rs
+++ b/crates/models/gptj/src/lib.rs
@@ -1,15 +1,14 @@
 //! An implementation of [GPT-J](https://huggingface.co/docs/transformers/model_doc/gptj) for the `llm` ecosystem.
 #![deny(missing_docs)]
 
-use std::{error::Error, path::Path};
+use std::error::Error;
 
 use ggml::Tensor;
 use llm_base::{
     ggml,
     model::{common, HyperparametersWriteError},
     util, FileType, InferenceParameters, InferenceSession, InferenceSessionConfig, KnownModel,
-    LoadError, LoadProgress, Mmap, ModelParameters, OutputRequest, TensorLoader, TokenId,
-    Vocabulary,
+    LoadError, Mmap, ModelParameters, OutputRequest, TensorLoader, TokenId, Vocabulary,
 };
 
 /// The GPT-J model. Ref: [GitHub](https://github.com/kingoflolz/mesh-transformer-jax/#gpt-j-6b)
@@ -43,22 +42,8 @@ pub struct GptJ {
     // Must be kept alive for the model
     _context: ggml::Context,
 }
-
 unsafe impl Send for GptJ {}
 unsafe impl Sync for GptJ {}
-
-impl GptJ {
-    /// Load a GPT-J model from the `path` and configure it per the `params`. The status
-    /// of the loading process will be reported through `load_progress_callback`. This
-    /// is a helper function on top of [llm_base::load].
-    pub fn load(
-        path: &Path,
-        params: ModelParameters,
-        load_progress_callback: impl FnMut(LoadProgress),
-    ) -> Result<GptJ, LoadError> {
-        llm_base::load(path, params, load_progress_callback)
-    }
-}
 
 impl KnownModel for GptJ {
     type Hyperparameters = Hyperparameters;

--- a/crates/models/llama/src/lib.rs
+++ b/crates/models/llama/src/lib.rs
@@ -1,7 +1,7 @@
 //! An implementation of [LLaMA](https://huggingface.co/docs/transformers/model_doc/llama) for the `llm` ecosystem.
 #![deny(missing_docs)]
 
-use std::{error::Error, path::Path};
+use std::error::Error;
 
 use llm_base::{
     ggml,
@@ -41,22 +41,8 @@ pub struct Llama {
     // Must be kept alive for the model
     _context: ggml::Context,
 }
-
 unsafe impl Send for Llama {}
 unsafe impl Sync for Llama {}
-
-impl Llama {
-    /// Load a LLaMA model from the `path` and configure it per the `params`. The status
-    /// of the loading process will be reported through `load_progress_callback`. This
-    /// is a helper function on top of [llm_base::load].
-    pub fn load(
-        path: &Path,
-        params: ModelParameters,
-        load_progress_callback: impl FnMut(LoadProgress),
-    ) -> Result<Llama, LoadError> {
-        llm_base::load(path, params, load_progress_callback)
-    }
-}
 
 impl KnownModel for Llama {
     type Hyperparameters = Hyperparameters;

--- a/crates/models/neox/src/lib.rs
+++ b/crates/models/neox/src/lib.rs
@@ -1,15 +1,14 @@
 //! An implementation of [GPT-NeoX](https://huggingface.co/docs/transformers/model_doc/gpt_neox) for the `llm` ecosystem.
 #![deny(missing_docs)]
 
-use std::{error::Error, path::Path};
+use std::error::Error;
 
 use ggml::Tensor;
 use llm_base::{
     ggml,
     model::{common, HyperparametersWriteError},
     util, FileType, InferenceParameters, InferenceSession, InferenceSessionConfig, KnownModel,
-    LoadError, LoadProgress, Mmap, ModelParameters, OutputRequest, TensorLoader, TokenId,
-    Vocabulary,
+    LoadError, Mmap, ModelParameters, OutputRequest, TensorLoader, TokenId, Vocabulary,
 };
 
 /// The GPT-NeoX model. Ref: [GitHub](https://github.com/EleutherAI/gpt-neox)
@@ -42,22 +41,8 @@ pub struct NeoX {
     // Must be kept alive for the model
     _context: ggml::Context,
 }
-
 unsafe impl Send for NeoX {}
 unsafe impl Sync for NeoX {}
-
-impl NeoX {
-    /// Load a GPT-NeoX model from the `path` and configure it per the `params`. The
-    /// status of the loading process will be reported through `load_progress_callback`.
-    /// This is a helper function on top of [llm_base::load].
-    pub fn load(
-        path: &Path,
-        params: ModelParameters,
-        load_progress_callback: impl FnMut(LoadProgress),
-    ) -> Result<NeoX, LoadError> {
-        llm_base::load(path, params, load_progress_callback)
-    }
-}
 
 impl KnownModel for NeoX {
     type Hyperparameters = Hyperparameters;


### PR DESCRIPTION
Pretty simple refactor - removes the duplicated `load` and moves it to the trait.