### PR TITLE
Dynamically calculate the LoRA patching context size

### DIFF
--- a/crates/ggml/src/format/loader.rs
+++ b/crates/ggml/src/format/loader.rs
@@ -77,11 +77,10 @@ impl TensorLoadInfo {
 
     /// Calculates the absolute size in bytes of the tensor's data, given the mmap flag.
     pub fn calc_absolute_size(&self, mmap: bool) -> usize {
-        let header_size = crate::Tensor::C_TYPE_SIZE + crate::OBJECT_SIZE;
         if mmap {
-            header_size
+            header_size()
         } else {
-            header_size + self.calc_size()
+            header_size() + self.calc_size()
         }
     }
 
@@ -102,6 +101,16 @@ impl TensorLoadInfo {
 /// Returns the size occupied by a tensor's data in bytes given the element type and number of elements.
 pub(crate) fn data_size(element_type: ElementType, n_elements: usize) -> usize {
     (crate::type_size(element_type) * n_elements) / crate::blck_size(element_type)
+}
+
+/// Returns the size of the ggml tensor header in bytes.
+pub(crate) fn header_size() -> usize {
+    crate::Tensor::C_TYPE_SIZE + crate::OBJECT_SIZE
+}
+
+/// Returns the size of a tensor in bytes given the element type and number of elements. This includes the tensor's header.
+pub fn tensor_size(element_type: ElementType, n_elements: usize) -> usize {
+    header_size() + data_size(element_type, n_elements)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/llm-base/src/loader.rs
+++ b/crates/llm-base/src/loader.rs
@@ -491,7 +491,7 @@ impl TensorLoader<LoadError> for MmapCompatibleLoader<'_> {
         let mut tensor = main_context.get_tensor(info)?;
 
         if let Some(lora_adapter) = &mut self.lora_adapter {
-            lora_adapter.patch(&info.name, &mut tensor)?;
+            lora_adapter.patch(info, &mut tensor)?;
             (self.load_progress_callback)(LoadProgress::LoraApplied {
                 name: name.to_owned(),
             });


### PR DESCRIPTION
The hardcoded context size resulted in errors, while loading adapters with larger tensors. To fix this the context  size is now calculated dynamically via the dimensions of the tensors.

Tested with this adapter: https://huggingface.co/LLukas22/vigogne-instruct-7b-lora-ggml and a 7B  LLaMA model.  