### PR TITLE
Update Gpt-NeoX implementation

### DIFF
--- a/binaries/llm-cli/src/cli_args.rs
+++ b/binaries/llm-cli/src/cli_args.rs
@@ -37,21 +37,6 @@ pub enum Args {
     NeoX {
         #[command(subcommand)]
         args: BaseArgs,
-
-        #[arg(long)]
-        /// By default, the GPT-NeoX architecture uses a parallel residual.
-        ///
-        /// This flag disables that, as some models out there are trained without it,
-        /// and the model format does not store this information.
-        no_parallel_residual: bool,
-    },
-    /// Use a model from the RedPajama GPT-NeoX family
-    ///
-    /// (GPT-NeoX with `use_parallel_residual` set to false)
-    #[clap(id = "redpajama")]
-    RedPajama {
-        #[command(subcommand)]
-        args: BaseArgs,
     },
 }
 

--- a/binaries/llm-cli/src/main.rs
+++ b/binaries/llm-cli/src/main.rs
@@ -29,21 +29,7 @@ fn main() -> Result<()> {
         Args::Bloom { args } => handle_args::<llm::models::Bloom>(args, None),
         Args::Gpt2 { args } => handle_args::<llm::models::Gpt2>(args, None),
         Args::GptJ { args } => handle_args::<llm::models::GptJ>(args, None),
-        Args::NeoX {
-            args,
-            no_parallel_residual,
-        } => handle_args::<llm::models::GptNeoX>(
-            args,
-            Some(llm::models::GptNeoXOverrides {
-                use_parallel_residual: !*no_parallel_residual,
-            }),
-        ),
-        Args::RedPajama { args } => handle_args::<llm::models::GptNeoX>(
-            args,
-            Some(llm::models::GptNeoXOverrides {
-                use_parallel_residual: false,
-            }),
-        ),
+        Args::NeoX { args } => handle_args::<llm::models::GptNeoX>(args, None),
     }
 }
 

--- a/crates/ggml/src/util.rs
+++ b/crates/ggml/src/util.rs
@@ -24,6 +24,19 @@ pub fn read_f32(reader: &mut dyn BufRead) -> Result<f32, std::io::Error> {
     Ok(f32::from_le_bytes(read_bytes::<4>(reader)?))
 }
 
+/// Read a `bool` represented as an `i32` from a reader.
+pub fn read_bool(reader: &mut dyn BufRead) -> Result<bool, std::io::Error> {
+    let val = i32::from_le_bytes(read_bytes::<4>(reader)?);
+    match val {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Invalid i32 value for bool: '{}'", val),
+        )),
+    }
+}
+
 /// Read a variable-length array of bytes from a reader.
 pub fn read_bytes_with_len(
     reader: &mut dyn BufRead,
@@ -47,6 +60,12 @@ pub fn write_u32(writer: &mut dyn Write, value: u32) -> Result<(), std::io::Erro
 /// Write a `f32` from a writer.
 pub fn write_f32(writer: &mut dyn Write, value: f32) -> Result<(), std::io::Error> {
     writer.write_all(&value.to_le_bytes())
+}
+
+/// Write a `bool` represented as an `i32` to a writer.
+pub fn write_bool(writer: &mut dyn Write, value: bool) -> Result<(), std::io::Error> {
+    let int_value: i32 = if value { 1 } else { 0 };
+    writer.write_all(&int_value.to_le_bytes())
 }
 
 // NOTE: Implementation from #![feature(buf_read_has_data_left)]

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_model_architecture_from_str() {
-        for arch in &ModelArchitecture::ALL {
+        for arch in ModelArchitecture::ALL {
             assert_eq!(
                 arch,
                 &arch.to_string().parse::<ModelArchitecture>().unwrap()

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -93,7 +93,7 @@ pub mod models {
     #[cfg(feature = "gptj")]
     pub use llm_gptj::{self as gptj, GptJ};
     #[cfg(feature = "gptneox")]
-    pub use llm_gptneox::{self as gptneox, GptNeoX, GptNeoXOverrides};
+    pub use llm_gptneox::{self as gptneox, GptNeoX};
     #[cfg(feature = "llama")]
     pub use llm_llama::{self as llama, Llama};
 }
@@ -116,14 +116,11 @@ pub enum ModelArchitecture {
     #[cfg(feature = "gptneox")]
     /// [GPT-NeoX](llm_gptneox)
     GptNeoX,
-    #[cfg(feature = "gptneox")]
-    /// RedPajama: [GPT-NeoX](llm_gptneox) with `use_parallel_residual` set to false
-    RedPajama,
 }
 
 impl ModelArchitecture {
     /// All available model architectures
-    pub const ALL: [Self; 6] = [
+    pub const ALL: [Self; 5] = [
         #[cfg(feature = "bloom")]
         Self::Bloom,
         #[cfg(feature = "gpt2")]
@@ -134,8 +131,6 @@ impl ModelArchitecture {
         Self::Llama,
         #[cfg(feature = "gptneox")]
         Self::GptNeoX,
-        #[cfg(feature = "gptneox")]
-        Self::RedPajama,
     ];
 }
 
@@ -177,8 +172,6 @@ impl FromStr for ModelArchitecture {
             "llama" => Ok(Llama),
             #[cfg(feature = "gptneox")]
             "gptneox" => Ok(GptNeoX),
-            #[cfg(feature = "gptneox")]
-            "redpajama" => Ok(RedPajama),
             m => Err(UnsupportedModelArchitecture(format!(
                 "{m} is not a supported model architecture"
             ))),
@@ -201,8 +194,6 @@ impl Display for ModelArchitecture {
             Llama => write!(f, "LLaMA"),
             #[cfg(feature = "gptneox")]
             GptNeoX => write!(f, "GPT-NeoX"),
-            #[cfg(feature = "gptneox")]
-            RedPajama => write!(f, "RedPajama"),
         }
     }
 }
@@ -249,19 +240,6 @@ pub fn load_dynamic(
         Llama => load_model::<models::Llama>(path, params, overrides, load_progress_callback)?,
         #[cfg(feature = "gptneox")]
         GptNeoX => load_model::<models::GptNeoX>(path, params, overrides, load_progress_callback)?,
-        #[cfg(feature = "gptneox")]
-        RedPajama => load_model::<models::GptNeoX>(
-            path,
-            params,
-            {
-                let mut overrides = overrides.unwrap_or_default();
-                overrides.merge(models::GptNeoXOverrides {
-                    use_parallel_residual: false,
-                });
-                Some(overrides)
-            },
-            load_progress_callback,
-        )?,
     };
 
     Ok(model)

--- a/crates/models/gptneox/src/lib.rs
+++ b/crates/models/gptneox/src/lib.rs
@@ -9,10 +9,8 @@ use llm_base::{
     ggml::{self, ElementType},
     model::{common, HyperparametersWriteError},
     util, FileType, InferenceParameters, InferenceSession, InferenceSessionConfig, KnownModel,
-    LoadError, Mmap, ModelDynamicOverrides, ModelParameters, OutputRequest, TensorLoader, TokenId,
-    Vocabulary,
+    LoadError, Mmap, ModelParameters, OutputRequest, TensorLoader, TokenId, Vocabulary,
 };
-use serde::{Deserialize, Serialize};
 
 /// The GPT-NeoX model. Ref: [GitHub](https://github.com/EleutherAI/gpt-neox)
 ///
@@ -48,51 +46,14 @@ pub struct GptNeoX {
 unsafe impl Send for GptNeoX {}
 unsafe impl Sync for GptNeoX {}
 
-#[derive(Serialize, Deserialize, Clone, Copy)]
-/// Overrides for the GPT-NeoX model.
-pub struct GptNeoXOverrides {
-    /// Whether to use a "parallel" formulation in each Transformer layer, which can provide a slight training
-    /// speedup at large scales (e.g. 20B).
-    ///
-    /// Defaults to `true`.
-    /// The RedPajama models use `false`.
-    pub use_parallel_residual: bool,
-}
-impl Default for GptNeoXOverrides {
-    fn default() -> Self {
-        Self {
-            use_parallel_residual: true,
-        }
-    }
-}
-impl From<ModelDynamicOverrides> for GptNeoXOverrides {
-    fn from(val: ModelDynamicOverrides) -> Self {
-        let mut overrides = GptNeoXOverrides::default();
-        if let Some(v) = val.get("use_parallel_residual") {
-            overrides.use_parallel_residual = v;
-        }
-        overrides
-    }
-}
-impl From<GptNeoXOverrides> for ModelDynamicOverrides {
-    fn from(val: GptNeoXOverrides) -> Self {
-        let mut overrides = ModelDynamicOverrides::default();
-        overrides.insert(
-            "use_parallel_residual".to_string(),
-            val.use_parallel_residual,
-        );
-        overrides
-    }
-}
-
 impl KnownModel for GptNeoX {
     type Hyperparameters = Hyperparameters;
-    type Overrides = GptNeoXOverrides;
+    type Overrides = ();
 
     fn new<E: Error>(
         hyperparameters: Hyperparameters,
         params: ModelParameters,
-        overrides: Option<Self::Overrides>,
+        _overrides: Option<Self::Overrides>,
         vocabulary: Vocabulary,
         tensor_loader: impl TensorLoader<E>,
     ) -> Result<Self, E>
@@ -147,11 +108,6 @@ impl KnownModel for GptNeoX {
             inference_parameters,
             ..
         } = params;
-
-        let mut hyperparameters = hyperparameters;
-        if let Some(overrides) = overrides {
-            hyperparameters.use_parallel_residual = overrides.use_parallel_residual;
-        }
 
         Ok(GptNeoX {
             hyperparameters,
@@ -468,12 +424,11 @@ pub struct Hyperparameters {
     pub n_layer: usize,
     /// n_rot
     pub n_rot: usize,
+    /// Whether to use a "parallel" formulation in each Transformer layer.
+    /// This is on for most models, but is off for some e.g. RedPajama.
+    pub use_parallel_residual: bool,
     /// file_type
     pub file_type: FileType,
-
-    /// Whether to use a "parallel" formulation in each Transformer layer.
-    /// This is on for most models, but is off for the RedPajama model.
-    pub use_parallel_residual: bool,
 }
 
 impl Default for Hyperparameters {
@@ -499,8 +454,8 @@ impl llm_base::Hyperparameters for Hyperparameters {
             n_head: util::read_i32(reader)?.try_into()?,
             n_layer: util::read_i32(reader)?.try_into()?,
             n_rot: util::read_i32(reader)?.try_into()?,
+            use_parallel_residual: util::read_bool(reader)?,
             file_type: util::read_filetype(reader)?,
-            use_parallel_residual: true,
         })
     }
 
@@ -511,6 +466,7 @@ impl llm_base::Hyperparameters for Hyperparameters {
         util::write_i32(writer, self.n_head.try_into()?)?;
         util::write_i32(writer, self.n_layer.try_into()?)?;
         util::write_i32(writer, self.n_rot.try_into()?)?;
+        util::write_bool(writer, self.use_parallel_residual)?;
         util::write_i32(writer, self.file_type.into())?;
         Ok(())
     }


### PR DESCRIPTION
This adds the new boolean `use_parallel_residual` hyperparameter to the Gpt-Neox implementation.

This also enables us to remove the RedPajama model overwrite.

I will use this branch to convert and quantize the models published by [Together](https://huggingface.co/togethercomputer).
