### PR TITLE
feat: support quantizing with a GGML container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +477,7 @@ dependencies = [
 name = "ggml"
 version = "0.1.1"
 dependencies = [
+ "anyhow",
  "ggml-sys",
  "rand",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 spinoff = { version = "0.7.0", default-features = false, features = ["dots2"] }
 thiserror = "1.0"
+anyhow = "1.0"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/binaries/llm-cli/src/cli_args.rs
+++ b/binaries/llm-cli/src/cli_args.rs
@@ -1,10 +1,10 @@
-use std::{fmt::Debug, path::PathBuf};
+use std::{fmt, path::PathBuf};
 
 use clap::{Parser, Subcommand, ValueEnum};
 use color_eyre::eyre::{Result, WrapErr};
 use llm::{
-    ElementType, InferenceParameters, InferenceSessionConfig, InvalidTokenBias, LoadProgress,
-    Model, ModelKVMemoryType, ModelParameters, TokenBias,
+    ggml_format, ElementType, InferenceParameters, InferenceSessionConfig, InvalidTokenBias,
+    LoadProgress, Model, ModelKVMemoryType, ModelParameters, TokenBias,
 };
 use rand::SeedableRng;
 
@@ -497,8 +497,39 @@ pub struct Quantize {
     #[arg()]
     pub destination: PathBuf,
 
+    /// The GGML container type to target.
+    ///
+    /// Note that using GGML requires the original model to have
+    /// an unscored vocabulary, which is not the case for newer models.
+    #[arg(short, long, default_value_t = SaveContainerType::GgjtV2)]
+    pub container_type: SaveContainerType,
+
     /// The format to convert to
     pub target: QuantizationTarget,
+}
+
+#[derive(Parser, Debug, ValueEnum, Clone, Copy)]
+pub enum SaveContainerType {
+    /// GGML container.
+    Ggml,
+    /// GGJT v2 container.
+    GgjtV2,
+}
+impl fmt::Display for SaveContainerType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SaveContainerType::Ggml => write!(f, "ggml"),
+            SaveContainerType::GgjtV2 => write!(f, "ggjt-v2"),
+        }
+    }
+}
+impl From<SaveContainerType> for ggml_format::SaveContainerType {
+    fn from(value: SaveContainerType) -> Self {
+        match value {
+            SaveContainerType::Ggml => ggml_format::SaveContainerType::Ggml,
+            SaveContainerType::GgjtV2 => ggml_format::SaveContainerType::GgjtV2,
+        }
+    }
 }
 
 #[derive(Parser, Debug, ValueEnum, Clone, Copy)]

--- a/binaries/llm-cli/src/main.rs
+++ b/binaries/llm-cli/src/main.rs
@@ -298,6 +298,7 @@ fn quantize<M: llm::KnownModel + 'static>(args: &cli_args::Quantize) -> Result<(
     llm::quantize::<M, _, _>(
         &mut source,
         &mut destination,
+        args.container_type.into(),
         args.target.into(),
         |progress| match progress {
             QuantizeProgress::HyperparametersLoaded => log::info!("Loaded hyperparameters"),

--- a/crates/ggml/Cargo.toml
+++ b/crates/ggml/Cargo.toml
@@ -12,3 +12,5 @@ ggml-sys = { path = "sys", version = "0.1.1" }
 
 [dev-dependencies]
 rand = { workspace = true }
+anyhow = { workspace = true }
+

--- a/crates/ggml/src/format/saver.rs
+++ b/crates/ggml/src/format/saver.rs
@@ -26,6 +26,10 @@ pub enum SaveError<E: Error> {
     #[error("invariant broken: {0}")]
     /// An invariant was broken.
     InvariantBroken(String),
+    /// An attempt was made to save a model with a container type that does not
+    /// support vocabulary scoring, despite the model having a scored vocabulary.
+    #[error("container type does not support vocabulary scoring")]
+    VocabularyScoringNotSupported,
 }
 
 /// A handler for saving a GGML model.
@@ -55,17 +59,49 @@ pub struct TensorSaveInfo {
     pub data: Vec<u8>,
 }
 
+/// The container of the model to save.
+///
+/// This is separate from [ContainerType] to ensure that the user
+/// does not accidentally use an unsupported container type.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum SaveContainerType {
+    /// The GGML container.
+    Ggml,
+    /// The GGJT container.
+    GgjtV2,
+}
+impl From<SaveContainerType> for ContainerType {
+    fn from(value: SaveContainerType) -> Self {
+        match value {
+            SaveContainerType::Ggml => ContainerType::Ggml,
+            SaveContainerType::GgjtV2 => ContainerType::Ggjt(2),
+        }
+    }
+}
+
 /// Saves a model to the given writer.
 ///
-/// Only GGJT version 2 is supported.
+/// Only GGML and GGJT version 2 are supported. If using GGML,
+/// the vocabulary *must* have scores of 0.0.
 pub fn save<E: Error, W: Write + Seek>(
     writer: &mut W,
     handler: &mut dyn SaveHandler<E>,
+    container_type: SaveContainerType,
     vocabulary: &[(Vec<u8>, f32)],
     tensor_names: &[String],
 ) -> Result<(), SaveError<E>> {
     // Write header and hyperparameters
-    ContainerType::Ggjt(2).write(writer)?;
+    match container_type {
+        SaveContainerType::Ggml => ContainerType::Ggml.write(writer)?,
+        SaveContainerType::GgjtV2 => ContainerType::Ggjt(2).write(writer)?,
+    }
+
+    if container_type == SaveContainerType::Ggml
+        && vocabulary.iter().any(|(_, score)| *score != 0.0)
+    {
+        return Err(SaveError::VocabularyScoringNotSupported);
+    }
+
     handler
         .write_hyperparameters(writer)
         .map_err(SaveError::ImplementationError)?;
@@ -74,7 +110,10 @@ pub fn save<E: Error, W: Write + Seek>(
     for (token, score) in vocabulary {
         util::write_u32(writer, token.len().try_into()?)?;
         writer.write_all(token)?;
-        util::write_f32(writer, *score)?;
+
+        if container_type != SaveContainerType::Ggml {
+            util::write_f32(writer, *score)?;
+        }
     }
 
     // Write tensors
@@ -109,10 +148,12 @@ pub fn save<E: Error, W: Write + Seek>(
         writer.write_all(name.as_bytes())?;
 
         // Align to nearest 32 bytes
-        let offset_curr = writer.stream_position()?;
-        let offset_aligned = (offset_curr + 31) & !31;
-        let padding = usize::try_from(offset_aligned - offset_curr)?;
-        writer.write_all(&vec![0; padding])?;
+        if container_type != SaveContainerType::Ggml {
+            let offset_curr = writer.stream_position()?;
+            let offset_aligned = (offset_curr + 31) & !31;
+            let padding = usize::try_from(offset_aligned - offset_curr)?;
+            writer.write_all(&vec![0; padding])?;
+        }
 
         // Write tensor data
         writer.write_all(&data)?;

--- a/crates/ggml/src/lib.rs
+++ b/crates/ggml/src/lib.rs
@@ -80,7 +80,7 @@ impl ContainerType {
     pub fn write(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
         match self {
             ContainerType::Ggml => {
-                util::write_u32(writer, FILE_MAGIC_GGMF)?;
+                util::write_u32(writer, FILE_MAGIC_GGML)?;
             }
             ContainerType::Ggmf(version) => {
                 util::write_u32(writer, FILE_MAGIC_GGMF)?;

--- a/crates/llm-base/src/loader.rs
+++ b/crates/llm-base/src/loader.rs
@@ -109,6 +109,24 @@ pub enum FileTypeFormat {
     /// All tensors are mostly stored as `Q5_1`, except for the 1D tensors (32-bit).
     MostlyQ5_1,
 }
+impl TryFrom<ggml::Type> for FileTypeFormat {
+    type Error = ();
+
+    fn try_from(value: ggml::Type) -> Result<Self, Self::Error> {
+        Ok(match value {
+            ggml::Type::Q4_0 => Self::MostlyQ4_0,
+            ggml::Type::Q4_1 => Self::MostlyQ4_1,
+            ggml::Type::Q5_0 => Self::MostlyQ5_0,
+            ggml::Type::Q5_1 => Self::MostlyQ5_1,
+            ggml::Type::Q8_0 => Self::MostlyQ8_0,
+            ggml::Type::Q8_1 => return Err(()),
+            ggml::Type::I32 => return Err(()),
+            ggml::Type::F16 => Self::MostlyF16,
+            ggml::Type::F32 => Self::F32,
+            ggml::Type::LegacyQ4_2 => Self::MostlyQ4_2,
+        })
+    }
+}
 
 /// Each variant represents a step within the process of loading the model.
 /// These can be used to report progress to the user.

--- a/crates/llm-base/src/lora.rs
+++ b/crates/llm-base/src/lora.rs
@@ -46,6 +46,10 @@ impl Hyperparameters for LoraParameters {
     fn file_type(&self) -> Option<FileType> {
         None
     }
+
+    fn file_type_mut(&mut self) -> Option<&mut FileType> {
+        None
+    }
 }
 
 /// [LoRA](https://arxiv.org/abs/2106.09685) adapter for a model.

--- a/crates/llm-base/src/model/mod.rs
+++ b/crates/llm-base/src/model/mod.rs
@@ -256,6 +256,9 @@ pub trait Hyperparameters: Sized + Default + Debug {
 
     /// Get the filetype of the model.
     fn file_type(&self) -> Option<FileType>;
+
+    /// Get mutable access to filetype of the model.
+    fn file_type_mut(&mut self) -> Option<&mut FileType>;
 }
 #[derive(Error, Debug)]
 /// Reported from functions that write

--- a/crates/llm-base/src/quantize.rs
+++ b/crates/llm-base/src/quantize.rs
@@ -112,6 +112,10 @@ pub enum QuantizeError {
     /// An error was encountered while writing the hyperparameters.
     #[error("an error was encountered while writing the hyperparameters")]
     HyperparametersWriteError(#[source] HyperparametersWriteError),
+    /// An attempt was made to save a model with a container type that does not
+    /// support vocabulary scoring, despite the model having a scored vocabulary.
+    #[error("container type does not support vocabulary scoring")]
+    VocabularyScoringNotSupported,
 }
 impl QuantizeError {
     pub(crate) fn from_format_error(value: SaveError<QuantizeError>, path: PathBuf) -> Self {
@@ -122,6 +126,9 @@ impl QuantizeError {
             SaveError::InvariantBroken(invariant) => {
                 QuantizeError::InvariantBroken { path, invariant }
             }
+            SaveError::VocabularyScoringNotSupported => {
+                QuantizeError::VocabularyScoringNotSupported
+            }
         }
     }
 }
@@ -130,6 +137,7 @@ impl QuantizeError {
 pub fn quantize<M: KnownModel, R: BufRead + Seek, W: Write + Seek>(
     reader: &mut R,
     writer: &mut W,
+    save_container_type: ggml::format::SaveContainerType,
     desired_type: ggml::Type,
     progress_callback: impl Fn(QuantizeProgress),
 ) -> Result<(), QuantizeError> {
@@ -156,11 +164,15 @@ pub fn quantize<M: KnownModel, R: BufRead + Seek, W: Write + Seek>(
 
     // Save the quantized model, quantizing as we go
     let Loader {
-        hyperparameters,
+        mut hyperparameters,
         vocabulary,
         tensors,
         ..
     } = loader;
+
+    if let Some(ft) = hyperparameters.file_type_mut() {
+        ft.quantization_version = ggml::QNT_VERSION;
+    }
 
     let vocabulary = vocabulary
         .id_to_token
@@ -175,6 +187,7 @@ pub fn quantize<M: KnownModel, R: BufRead + Seek, W: Write + Seek>(
     ggml::format::save(
         writer,
         &mut saver,
+        save_container_type,
         &vocabulary,
         &tensors.keys().cloned().collect::<Vec<_>>(),
     )

--- a/crates/llm-base/src/quantize.rs
+++ b/crates/llm-base/src/quantize.rs
@@ -172,6 +172,9 @@ pub fn quantize<M: KnownModel, R: BufRead + Seek, W: Write + Seek>(
 
     if let Some(ft) = hyperparameters.file_type_mut() {
         ft.quantization_version = ggml::QNT_VERSION;
+        ft.format = desired_type
+            .try_into()
+            .expect("format has no corresponding ftype");
     }
 
     let vocabulary = vocabulary

--- a/crates/models/bloom/src/lib.rs
+++ b/crates/models/bloom/src/lib.rs
@@ -458,6 +458,10 @@ impl llm_base::Hyperparameters for Hyperparameters {
     fn file_type(&self) -> Option<FileType> {
         Some(self.file_type)
     }
+
+    fn file_type_mut(&mut self) -> Option<&mut FileType> {
+        Some(&mut self.file_type)
+    }
 }
 
 struct Layer {

--- a/crates/models/gpt2/src/lib.rs
+++ b/crates/models/gpt2/src/lib.rs
@@ -393,6 +393,10 @@ impl llm_base::Hyperparameters for Hyperparameters {
     fn file_type(&self) -> Option<FileType> {
         Some(self.file_type)
     }
+
+    fn file_type_mut(&mut self) -> Option<&mut FileType> {
+        Some(&mut self.file_type)
+    }
 }
 
 struct Layer {

--- a/crates/models/gptj/src/lib.rs
+++ b/crates/models/gptj/src/lib.rs
@@ -386,6 +386,10 @@ impl llm_base::Hyperparameters for Hyperparameters {
     fn file_type(&self) -> Option<FileType> {
         Some(self.file_type)
     }
+
+    fn file_type_mut(&mut self) -> Option<&mut FileType> {
+        Some(&mut self.file_type)
+    }
 }
 
 struct Layer {

--- a/crates/models/gptneox/src/lib.rs
+++ b/crates/models/gptneox/src/lib.rs
@@ -522,6 +522,10 @@ impl llm_base::Hyperparameters for Hyperparameters {
     fn file_type(&self) -> Option<FileType> {
         Some(self.file_type)
     }
+
+    fn file_type_mut(&mut self) -> Option<&mut FileType> {
+        Some(&mut self.file_type)
+    }
 }
 
 struct Layer {

--- a/crates/models/llama/src/lib.rs
+++ b/crates/models/llama/src/lib.rs
@@ -429,6 +429,10 @@ impl llm_base::Hyperparameters for Hyperparameters {
     fn file_type(&self) -> Option<FileType> {
         Some(self.file_type)
     }
+
+    fn file_type_mut(&mut self) -> Option<&mut FileType> {
+        Some(&mut self.file_type)
+    }
 }
 
 struct Layer {

--- a/crates/models/mpt/src/lib.rs
+++ b/crates/models/mpt/src/lib.rs
@@ -333,10 +333,7 @@ impl llm_base::Hyperparameters for Hyperparameters {
             n_vocab: util::read_i32(reader)?.try_into()?,
             alibi_bias_max: util::read_f32(reader)?,
             clip_kqv: util::read_f32(reader)?,
-            file_type: {
-                let ftype = util::read_i32(reader)?;
-                FileType::try_from(ftype).map_err(|_| LoadError::UnsupportedFileType(ftype))?
-            },
+            file_type: util::read_filetype(reader)?,
         };
 
         Ok(hyperparameters)
@@ -348,6 +345,8 @@ impl llm_base::Hyperparameters for Hyperparameters {
         util::write_i32(writer, self.n_head.try_into()?)?;
         util::write_i32(writer, self.n_layer.try_into()?)?;
         util::write_i32(writer, self.n_vocab.try_into()?)?;
+        util::write_f32(writer, self.alibi_bias_max)?;
+        util::write_f32(writer, self.clip_kqv)?;
         util::write_i32(writer, self.file_type.into())?;
         Ok(())
     }

--- a/crates/models/mpt/src/lib.rs
+++ b/crates/models/mpt/src/lib.rs
@@ -359,6 +359,10 @@ impl llm_base::Hyperparameters for Hyperparameters {
     fn file_type(&self) -> Option<FileType> {
         Some(self.file_type)
     }
+
+    fn file_type_mut(&mut self) -> Option<&mut FileType> {
+        Some(&mut self.file_type)
+    }
 }
 
 struct Layer {


### PR DESCRIPTION
As requested by @LLukas22, this adds a `-c` option to `quantize` that lets you output GGML files. This should enable compatibility with the GGML example implementations of GPT-NeoX etc.