### PR TITLE
Typo fix in extern function name

### DIFF
--- a/crates/ggml/sys/src/lib.rs
+++ b/crates/ggml/sys/src/lib.rs
@@ -1144,7 +1144,7 @@ extern "C" {
     ) -> *mut ggml_tensor;
 }
 extern "C" {
-    pub fn gml_diag_mask_zero_inplace(
+    pub fn ggml_diag_mask_zero_inplace(
         ctx: *mut ggml_context,
         a: *mut ggml_tensor,
         n_past: ::std::os::raw::c_int,


### PR DESCRIPTION
Was probably being optimized away as dead code, hence no error.