### PR TITLE
Fix perplexity calculation

### DIFF
--- a/binaries/llm-cli/src/cli_args.rs
+++ b/binaries/llm-cli/src/cli_args.rs
@@ -118,9 +118,16 @@ pub struct Infer {
     #[arg(long, default_value = None)]
     pub persist_session: Option<PathBuf>,
 
-    /// Calculate and print perplexity of the model over the prompt.
+    /// Calculate perplexity of the model over the prompt.
+    ///
+    /// You will need to supply `--stats` to see the perplexity.
     #[arg(long, default_value_t = false)]
     pub perplexity: bool,
+
+    /// Output statistics about the time taken to perform inference, among other
+    /// things.
+    #[arg(long, default_value_t = false)]
+    pub stats: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/binaries/llm-cli/src/main.rs
+++ b/binaries/llm-cli/src/main.rs
@@ -134,8 +134,14 @@ fn perplexity<M: llm::KnownModel + 'static>(
     );
     let parameters = args.generate.inference_parameters(model.eot_token_id());
 
-    let perplexity = session.perplexity(model.as_ref(), &parameters, prompt.as_str())?;
-    println!("Perplexity: {}", perplexity);
+    session.perplexity(
+        model.as_ref(),
+        &parameters,
+        prompt.as_str(),
+        |chunk, perplexity| {
+            println!("Perplexity[{chunk}]: {perplexity}");
+        },
+    )?;
 
     Ok(())
 }

--- a/binaries/llm-cli/src/main.rs
+++ b/binaries/llm-cli/src/main.rs
@@ -93,7 +93,13 @@ fn infer<M: llm::KnownModel + 'static>(
     println!();
 
     match res {
-        Ok(_) => (),
+        Ok(stats) => {
+            if args.stats {
+                println!();
+                println!("{}", stats);
+                println!();
+            }
+        }
         Err(InferenceError::ContextFull) => {
             log::warn!("Context window full, stopping inference.")
         }

--- a/crates/llm-base/src/inference_session.rs
+++ b/crates/llm-base/src/inference_session.rs
@@ -660,25 +660,26 @@ impl Default for InferenceStats {
 }
 impl Display for InferenceStats {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let mut stats = format!(
-            "feed_prompt_duration: {}ms\n\
-            prompt_tokens: {}\n\
-            predict_duration: {}ms\n\
-            predict_tokens: {}\n\
-            per_token_duration: {:.3}ms",
-            self.feed_prompt_duration.as_millis(),
-            self.prompt_tokens,
-            self.predict_duration.as_millis(),
-            self.predict_tokens,
-            (self.predict_duration.as_millis() as f64) / (self.predict_tokens as f64)
-        );
+        let Self {
+            feed_prompt_duration,
+            prompt_tokens,
+            predict_duration,
+            predict_tokens,
+        } = *self;
 
-        // Show perplexity if it was calculated.
-        if let Some(perplexity) = self.perplexity {
-            stats += &format!("\nperplexity: {:.4}", perplexity);
-        }
+        let feed_prompt_duration = feed_prompt_duration.as_millis();
+        let predict_duration = predict_duration.as_millis();
+        let per_token_duration = if predict_tokens == 0 {
+            0.0
+        } else {
+            predict_duration as f64 / predict_tokens as f64
+        };
 
-        write!(f, "{}", stats)
+        writeln!(f, "feed_prompt_duration: {}ms", feed_prompt_duration)?;
+        writeln!(f, "prompt_tokens: {}", prompt_tokens)?;
+        writeln!(f, "predict_duration: {}ms", predict_duration)?;
+        writeln!(f, "predict_tokens: {}", predict_tokens)?;
+        write!(f, "per_token_duration: {:.3}ms", per_token_duration)
     }
 }
 

--- a/crates/llm-base/src/lib.rs
+++ b/crates/llm-base/src/lib.rs
@@ -7,8 +7,6 @@
 //! As a user, you probably want to use the [llm](https://crates.io/crates/llm) crate instead.
 #![deny(missing_docs)]
 
-use thiserror::Error;
-
 mod inference_session;
 mod loader;
 mod lora;
@@ -22,8 +20,9 @@ pub use ggml;
 pub use ggml::Type as ElementType;
 
 pub use inference_session::{
-    feed_prompt_callback, InferenceFeedback, InferenceRequest, InferenceResponse, InferenceSession,
-    InferenceSessionConfig, InferenceSnapshot, InferenceStats, ModelKVMemoryType, SnapshotError,
+    feed_prompt_callback, InferenceError, InferenceFeedback, InferenceRequest, InferenceResponse,
+    InferenceSession, InferenceSessionConfig, InferenceSnapshot, InferenceStats, ModelKVMemoryType,
+    SnapshotError,
 };
 pub use loader::{
     load, load_progress_callback_stdout, ContainerType, FileType, FileTypeFormat, LoadError,
@@ -37,7 +36,7 @@ pub use model::{
 };
 pub use quantize::{quantize, QuantizeError, QuantizeProgress};
 pub use util::TokenUtf8Buffer;
-pub use vocabulary::{InvalidTokenBias, TokenBias, TokenId, Vocabulary};
+pub use vocabulary::{InvalidTokenBias, Prompt, TokenBias, TokenId, TokenizationError, Vocabulary};
 
 #[derive(Clone, Debug, PartialEq)]
 /// The parameters for text generation.
@@ -78,23 +77,4 @@ impl Default for InferenceParameters {
             repetition_penalty_last_n: 512,
         }
     }
-}
-
-#[derive(Error, Debug)]
-/// Errors encountered during the inference process.
-pub enum InferenceError {
-    #[error("an invalid token was encountered during tokenization")]
-    /// During tokenization, one of the produced tokens was invalid / zero.
-    TokenizationFailed,
-    #[error("the context window is full")]
-    /// The context window for the model is full.
-    ContextFull,
-    #[error("reached end of text")]
-    /// The model has produced an end of text token, signalling that it thinks that the text should end here.
-    ///
-    /// Note that this error *can* be ignored and inference can continue, but the results are not guaranteed to be sensical.
-    EndOfText,
-    #[error("the user-specified callback returned an error")]
-    /// The user-specified callback returned an error.
-    UserCallback(Option<Box<dyn std::error::Error>>),
 }

--- a/crates/llm-base/src/vocabulary.rs
+++ b/crates/llm-base/src/vocabulary.rs
@@ -21,6 +21,7 @@ pub enum TokenizationError {
 /// The vocabulary used by a model.
 #[derive(Debug, Clone, Default)]
 pub struct Vocabulary {
+    // TODO: make these private
     /// Maps every integer (index) token ID to its corresponding token.
     pub id_to_token: Vec<Token>,
 
@@ -61,6 +62,16 @@ impl Vocabulary {
     /// Converts a token index to the token it represents in this vocabulary.
     pub fn token(&self, idx: usize) -> &[u8] {
         &self.id_to_token[idx]
+    }
+
+    /// Returns the number of tokens in the vocabulary.
+    pub fn len(&self) -> usize {
+        self.id_to_token.len()
+    }
+
+    /// Returns whether the vocabulary is empty.
+    pub fn is_empty(&self) -> bool {
+        self.id_to_token.is_empty()
     }
 
     // SentencePiece implementation after https://guillaume-be.github.io/2020-05-30/sentence_piece

--- a/crates/llm/examples/inference.rs
+++ b/crates/llm/examples/inference.rs
@@ -43,7 +43,7 @@ fn main() {
         model.as_ref(),
         &mut rand::thread_rng(),
         &InferenceRequest {
-            prompt,
+            prompt: prompt.into(),
             ..Default::default()
         },
         // OutputRequest

--- a/crates/llm/examples/vicuna-chat.rs
+++ b/crates/llm/examples/vicuna-chat.rs
@@ -70,7 +70,9 @@ fn main() {
                         model.as_ref(),
                         &mut rng,
                         &InferenceRequest {
-                            prompt: format!("{user_name}: {line}\n{character_name}:").as_str(),
+                            prompt: format!("{user_name}: {line}\n{character_name}:")
+                                .as_str()
+                                .into(),
                             ..Default::default()
                         },
                         &mut Default::default(),

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -79,8 +79,8 @@ pub use llm_base::{
     InferenceParameters, InferenceRequest, InferenceResponse, InferenceSession,
     InferenceSessionConfig, InferenceSnapshot, InferenceStats, InvalidTokenBias, KnownModel,
     LoadError, LoadProgress, Loader, Model, ModelDynamicOverrideValue, ModelDynamicOverrides,
-    ModelKVMemoryType, ModelParameters, OutputRequest, QuantizeError, QuantizeProgress,
-    SnapshotError, TokenBias, TokenId, TokenUtf8Buffer, Vocabulary,
+    ModelKVMemoryType, ModelParameters, OutputRequest, Prompt, QuantizeError, QuantizeProgress,
+    SnapshotError, TokenBias, TokenId, TokenUtf8Buffer, TokenizationError, Vocabulary,
 };
 
 use serde::Serialize;

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -40,7 +40,7 @@
 //!     // the prompt to use for text generation, as well as other
 //!     // inference parameters
 //!     &llm::InferenceRequest {
-//!         prompt: "Rust is a cool programming language because",
+//!         prompt: "Rust is a cool programming language because".into(),
 //!         ..Default::default()
 //!     },
 //!     // llm::OutputRequest


### PR DESCRIPTION
There were some errors (one quite big) with https://github.com/rustformers/llm/pull/248 for larger files which caused it to panic with a large context window.

I believe this fixes most of those cases. I'm limited in my testing abilities, so if someone else could run perplexity checks for a few models, that would be better.