### PR TITLE
Fix embeddings extraction for all models

### DIFF
--- a/crates/llm/examples/embeddings.rs
+++ b/crates/llm/examples/embeddings.rs
@@ -49,11 +49,7 @@ fn main() {
     };
 
     // Load model
-    let model_params = llm::ModelParameters {
-        prefer_mmap: true,
-        context_size: 4096,
-        lora_adapters: None,
-    };
+    let model_params = llm::ModelParameters::default();
     let model = llm::load_dynamic(
         model_architecture,
         &model_path,
@@ -124,7 +120,7 @@ fn get_embeddings(
     let vocab = model.vocabulary();
     let beginning_of_sentence = true;
     let query_token_ids = vocab
-        .tokenize(&format!(" {}", query), beginning_of_sentence)
+        .tokenize(&format!("{}", query), beginning_of_sentence)
         .unwrap()
         .iter()
         .map(|(_, tok)| *tok)

--- a/crates/models/bloom/src/lib.rs
+++ b/crates/models/bloom/src/lib.rs
@@ -344,6 +344,8 @@ impl KnownModel for Bloom {
             &input_layer,
         );
 
+        let embeddings_tensor: ggml::Tensor = input_layer.share();
+
         // lm_head
         input_layer = ctx0.op_mul_mat(&self.output, &input_layer);
 
@@ -354,7 +356,7 @@ impl KnownModel for Bloom {
         // finish evaluation
         common::read_last_token(session, &input_layer, n_vocab, input_len);
         common::extract_logits(output_request, &input_layer, n_vocab, input_len);
-        common::extract_embeddings(output_request, &embd, n_embd, input_len);
+        common::extract_embeddings(output_request, &embeddings_tensor, n_embd, input_len);
         common::update_session(session, &ctx0, input_tokens.len(), input_len);
     }
 

--- a/crates/models/gpt2/src/lib.rs
+++ b/crates/models/gpt2/src/lib.rs
@@ -295,6 +295,8 @@ impl KnownModel for Gpt2 {
             &ctx0.op_repeat(&self.ln_f_b, &input_layer),
         );
 
+        let embeddings_tensor: ggml::Tensor = input_layer.share();
+
         input_layer = ctx0.op_mul_mat(&self.lm_head, &input_layer);
 
         // run the computation
@@ -304,7 +306,7 @@ impl KnownModel for Gpt2 {
         // finish evaluation
         common::read_last_token(session, &input_layer, n_vocab, input_len);
         common::extract_logits(output_request, &input_layer, n_vocab, input_len);
-        common::extract_embeddings(output_request, &embd, n_embd, input_len);
+        common::extract_embeddings(output_request, &embeddings_tensor, n_embd, input_len);
         common::update_session(session, &ctx0, input_tokens.len(), input_len);
     }
 

--- a/crates/models/gptj/src/lib.rs
+++ b/crates/models/gptj/src/lib.rs
@@ -272,6 +272,8 @@ impl KnownModel for GptJ {
             &ctx0.op_repeat(&self.ln_f_b, &input_layer),
         );
 
+        let embeddings_tensor: ggml::Tensor = input_layer.share();
+
         // lm_head
         input_layer = ctx0.op_mul_mat(&self.lmh_g, &input_layer);
         input_layer = ctx0.op_add(&ctx0.op_repeat(&self.lmh_b, &input_layer), &input_layer);
@@ -283,7 +285,7 @@ impl KnownModel for GptJ {
         // finish evaluation
         common::read_last_token(session, &input_layer, n_vocab, input_len);
         common::extract_logits(output_request, &input_layer, n_vocab, input_len);
-        common::extract_embeddings(output_request, &embd, n_embd, input_len);
+        common::extract_embeddings(output_request, &embeddings_tensor, n_embd, input_len);
         common::update_session(session, &ctx0, input_tokens.len(), input_len);
     }
 

--- a/crates/models/gptneox/src/lib.rs
+++ b/crates/models/gptneox/src/lib.rs
@@ -317,6 +317,8 @@ impl KnownModel for GptNeoX {
             &ctx0.op_repeat(&self.ln_f_b, &input_layer),
         );
 
+        let embeddings_tensor: ggml::Tensor = input_layer.share();
+
         // Disable the scratchbuffer
         ctx0.use_scratch(None);
 
@@ -330,7 +332,7 @@ impl KnownModel for GptNeoX {
         // finish evaluation
         common::read_last_token(session, &input_layer, n_vocab, n);
         common::extract_logits(output_request, &input_layer, n_vocab, n);
-        common::extract_embeddings(output_request, &embd, n_embd, n);
+        common::extract_embeddings(output_request, &embeddings_tensor, n_embd, n);
         common::update_session(session, &ctx0, input_tokens.len(), n);
     }
 

--- a/crates/models/mpt/src/lib.rs
+++ b/crates/models/mpt/src/lib.rs
@@ -251,6 +251,8 @@ impl KnownModel for Mpt {
         input_layer = ctx0.op_norm(&input_layer);
         input_layer = ctx0.op_mul(&ctx0.op_repeat(&self.norm, &input_layer), &input_layer);
 
+        let embeddings_tensor: ggml::Tensor = input_layer.share();
+
         // disable scratch buffer for last layer
         ctx0.use_scratch(None);
         // output embedding weight tied to input embedding
@@ -263,7 +265,7 @@ impl KnownModel for Mpt {
         // finish evaluation
         common::read_last_token(session, &input_layer, n_vocab, input_len);
         common::extract_logits(output_request, &input_layer, n_vocab, input_len);
-        common::extract_embeddings(output_request, &embd, n_embd, input_len);
+        common::extract_embeddings(output_request, &embeddings_tensor, n_embd, input_len);
         common::update_session(session, &ctx0, input_tokens.len(), input_len);
     }
 


### PR DESCRIPTION
Apply the fixed code for embeddings extraction to all models to avoid assertion errors. #288 