### PR TITLE
Default to f16 model memory k/v in llm CLI and InferenceSessionConfig

### DIFF
--- a/binaries/llm-cli/src/cli_args.rs
+++ b/binaries/llm-cli/src/cli_args.rs
@@ -244,10 +244,16 @@ pub struct Generate {
     #[arg(long, default_value = None)]
     pub seed: Option<u64>,
 
-    /// Use 16-bit floats for model memory key and value. Ignored when restoring
-    /// from the cache.
-    #[arg(long, default_value_t = false)]
-    pub float16: bool,
+    /// Use 16-bit floats for model memory key and value. Ignored but allowed for
+    /// backwards compatibility: this is now the default
+    #[arg(long = "float16", hide = true)]
+    pub _float16: bool,
+
+    /// Use 32-bit floats for model memory key and value.
+    /// Not recommended: doubles size without a measurable quality increase.
+    /// Ignored when restoring from the cache
+    #[arg(long = "no-float16", default_value_t = false)]
+    pub no_float16: bool,
 
     /// A comma separated list of token biases. The list should be in the format
     /// "TID=BIAS,TID=BIAS" where TID is an integer token ID and BIAS is a
@@ -287,10 +293,10 @@ impl Generate {
     }
 
     pub fn inference_session_config(&self) -> InferenceSessionConfig {
-        let mem_typ = if self.float16 {
-            ModelKVMemoryType::Float16
-        } else {
+        let mem_typ = if self.no_float16 {
             ModelKVMemoryType::Float32
+        } else {
+            ModelKVMemoryType::Float16
         };
         InferenceSessionConfig {
             memory_k_type: mem_typ,

--- a/crates/llm-base/src/inference_session.rs
+++ b/crates/llm-base/src/inference_session.rs
@@ -566,8 +566,8 @@ pub struct InferenceSessionConfig {
 impl Default for InferenceSessionConfig {
     fn default() -> Self {
         Self {
-            memory_k_type: ModelKVMemoryType::Float32,
-            memory_v_type: ModelKVMemoryType::Float32,
+            memory_k_type: ModelKVMemoryType::Float16,
+            memory_v_type: ModelKVMemoryType::Float16,
         }
     }
 }


### PR DESCRIPTION
Using 32bit values doesn't increase quality in a measurable way, see discussion here: https://github.com/ggerganov/llama.cpp/discussions/1593

The current default doubles memory consumption/size of prompt caches without a measurable upside. This pull changes the default to 16bit.

Allows `--float16` for backward compatibility.

Adds `--no-float16` flag to allow using 32bit memory.

***

Don't know if it's just me but I can't even run `llm llama infer --help` from the main branch:

```
The application panicked (crashed).
Message:  Command infer: Argument names must be unique, but 'vocabulary_path' is in use by more than one argument or group
```