### PR TITLE
fix(metal): patch ggml-metal.m with shader code

### DIFF
--- a/crates/ggml/sys/build.rs
+++ b/crates/ggml/sys/build.rs
@@ -201,10 +201,24 @@ fn enable_metal(build: &mut cc::Build, out_dir: &Path) {
             panic!("ggml-metal.m does not contain the needle to be replaced; the patching logic needs to be reinvestigated. Contact a `llm` developer!");
         }
 
+        // Replace the runtime read of the file with a compile-time string
         let ggml_metal = ggml_metal.replace(
             needle,
             &format!(r#"NSString * src  = @"{ggml_metal_metal}";"#),
         );
+
+        // Replace the judicious use of `fprintf` with the already-existing `metal_printf`,
+        // backing up the definition of `metal_printf` first
+        let ggml_metal = ggml_metal
+            .replace(
+                r#"#define metal_printf(...) fprintf(stderr, __VA_ARGS__)"#,
+                "METAL_PRINTF_DEFINITION",
+            )
+            .replace("fprintf(stderr,", "metal_printf(")
+            .replace(
+                "METAL_PRINTF_DEFINITION",
+                r#"#define metal_printf(...) fprintf(stderr, __VA_ARGS__)"#,
+            );
 
         let patched_ggml_metal_path = out_dir.join("ggml-metal.m");
         std::fs::write(&patched_ggml_metal_path, ggml_metal)


### PR DESCRIPTION
Alternate fix to #324 (thanks for the inspiration!)

The Rust build script has the ability to create new files, and use them as fodder for the build process. We can use this to create an alternate `ggml-metal.m` that embeds the Metal shader source code and sidestep the issue of runtime loading entirely.

Let me know if you're OK with this @pixelspark @nightscape !