### PR TITLE
feat: automatically run checks before commit

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --all --verbose
   fmt:
     name: Clippy, formatting and docs
     runs-on: ubuntu-latest

--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,0 +1,5 @@
+[hooks]
+pre-commit = "cargo run -p precommit-check"
+
+[logging]
+verbose = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ci_info"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f638c70e8c5753795cc9a8c07c44da91554a09e4cf11a7326e8161b0a3c45e"
+dependencies = [
+ "envmnt",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +679,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "envmnt"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d328fc287c61314c4a61af7cfdcbd7e678e39778488c7cb13ec133ce0f4059"
+dependencies = [
+ "fsio",
+ "indexmap",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +821,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsio"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +889,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1295,6 +1329,7 @@ dependencies = [
  "log",
  "num_cpus",
  "rand",
+ "rusty-hook",
  "rustyline",
  "spinoff",
  "zstd 0.12.3+zstd.1.5.2",
@@ -1472,6 +1507,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "nias"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
 
 [[package]]
 name = "nibble_vec"
@@ -1683,6 +1724,10 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precommit-check"
+version = "0.1.0"
 
 [[package]]
 name = "prettyplease"
@@ -1898,6 +1943,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rusty-hook"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96cee9be61be7e1cbadd851e58ed7449c29c620f00b23df937cb9cbc04ac21a3"
+dependencies = [
+ "ci_info",
+ "getopts",
+ "nias",
+ "toml",
 ]
 
 [[package]]
@@ -2311,6 +2368,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/binaries/llm-cli/Cargo.toml
+++ b/binaries/llm-cli/Cargo.toml
@@ -28,6 +28,9 @@ num_cpus = "1.15.0"
 color-eyre = { version = "0.6.2", default-features = false }
 zstd = { version = "0.12", default-features = false }
 
+[dev-dependencies]
+rusty-hook = "^0.11.2"
+
 [features]
 cublas = ["llm/cublas"]
 clblast = ["llm/clblast"]

--- a/binaries/precommit-check/Cargo.toml
+++ b/binaries/precommit-check/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "precommit-check"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[package.metadata.release]
+release = false

--- a/binaries/precommit-check/README.md
+++ b/binaries/precommit-check/README.md
@@ -1,0 +1,3 @@
+# precommit-check
+
+Helper script to run pre-commit checks on a repository. Used with `rusty-hook` to execute all of the checks and early exit if any of them fail.

--- a/binaries/precommit-check/src/main.rs
+++ b/binaries/precommit-check/src/main.rs
@@ -1,0 +1,16 @@
+fn main() {
+    // Ensure that these match `.github/workflows/rust.yml`.
+    cmd("cargo", &["check"]);
+    cmd("cargo", &["test", "--all"]);
+    cmd("cargo", &["fmt", "--check", "--all"]);
+    cmd("cargo", &["doc", "--workspace", "--exclude", "llm-cli"]);
+    cmd("cargo", &["clippy", "--", "-Dclippy::all"]);
+}
+
+fn cmd(cmd: &str, args: &[&str]) {
+    println!("=== Running command: {cmd} {args:?}");
+    let mut child = std::process::Command::new(cmd).args(args).spawn().unwrap();
+    if !child.wait().unwrap().success() {
+        panic!("Failed to run command: {} {:?}", cmd, args);
+    }
+}

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -9,16 +9,10 @@ or on [Discord](https://discord.gg/YB9WaXYAWU)!
 ## Checking Changes
 
 This project uses a [GitHub workflow](../.github/workflows/rust.yml) to enforce
-code standards - it will execute the following commands, which can be performed
-locally for faster turnaround and a better developer experience:
+code standards.
 
-```shell
-cargo check
-cargo test
-cargo fmt --all
-cargo doc --workspace --exclude llm-cli
-cargo clippy --fix --allow-dirty -- -Dclippy::all
-```
+The `rusty-hook` project is used to run a similar set of checks automatically before committing.
+If you would like to run these checks locally, use `cargo run -p precommit-check`.
 
 ## Regenerating GGML Bindings
 


### PR DESCRIPTION
I'm very bad at running checks locally before making commits, so I figured I'd make it everyone else's problem.

This uses `rusty-hook` to set up a Git pre-commit hook that ensures that your commit will not fail CI.

I could be convinced to make it a pre-push hook, but I think this is the right call.