### PR TITLE
Improve model architecture error message

### DIFF
--- a/crates/llm-base/src/loader.rs
+++ b/crates/llm-base/src/loader.rs
@@ -338,7 +338,9 @@ pub enum LoadError {
     /// There is insufficient information to guess the model architecture from the provided file.
     ///
     /// A model architecture must be provided to load the model.
-    #[error("could not guess model architecture from {path:?}")]
+    #[error(
+        "could not guess model architecture from {path:?}. Please provide a model architecture."
+    )]
     MissingModelArchitecture {
         /// The path that failed.
         path: PathBuf,

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -149,7 +149,7 @@ macro_rules! define_models {
                     )*
 
                     _ => Err(UnsupportedModelArchitecture(format!(
-                        "{s} is not a supported model architecture"
+                        "{s} is not one of supported model architectures: {:?}", ModelArchitecture::ALL
                     ))),
                 }
             }


### PR DESCRIPTION
When providing an incorrect model architecture:

```
error: invalid value 'llama1' for '--model-architecture <MODEL_ARCHITECTURE>': llama1 is not one of supported model architectures: [Bloom, Gpt2, GptJ, GptNeoX, Llama, Mpt]
```

It is much easier for users to know what available model architectures are.