### PR TITLE
Fix linux CLBlast build and add CI for accelerated builds  

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,14 +78,16 @@ jobs:
         with:
           cuda: '12.1.0'
           method: 'network'
-          sub-packages: '["nvcc","cudart","cublas"]'
+          #See e.g. https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
+          sub-packages: '["nvcc","compiler","libraries","libraries-dev","cudart","cudart-dev","libcublas","libcublas-dev"]'
       - uses: Jimver/cuda-toolkit@v0.2.10
         if: matrix.os == 'windows-latest'
         id: cuda-toolkit-windows
         with:
           cuda: '12.1.0'
           method: 'network'
-          sub-packages: '["nvcc","cudart","visual_studio_integration","cublas_dev"]'
+          #See https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software
+          sub-packages: '["nvcc","cudart","visual_studio_integration","cublas_dev","cublas"]'
       - uses: dtolnay/rust-toolchain@stable
       - name: Check
         run: cargo check --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           cuda: '12.1.0'
           method: 'network'
-          sub-packages: '["nvcc","cudart","cublas_dev"]'
+          sub-packages: '["nvcc","cudart","cublas"]'
       - uses: Jimver/cuda-toolkit@v0.2.10
         if: matrix.os == 'windows-latest'
         id: cuda-toolkit-windows

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,3 +46,70 @@ jobs:
         env:
           RUSTDOCFLAGS: -Dwarnings
         run: cargo doc --workspace --exclude llm-cli
+
+  metal:
+    name: Build with metal support
+    runs-on: macos-latest
+    steps: 
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - uses: dtolnay/rust-toolchain@stable
+    - name: Check
+      run: cargo check --verbose
+    - name: Build
+      run: cargo build --verbose --features metal
+
+  cuda:
+    name: Build with cuda support
+    strategy:
+    # Don't stop building if it fails on an OS
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps: 
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: Jimver/cuda-toolkit@v0.2.10
+        if: matrix.os == 'ubuntu-latest'
+        id: cuda-toolkit-linux
+        with:
+          cuda: '12.1.0'
+          method: 'network'
+          sub-packages: '["nvcc","cudart","cublas_dev"]'
+      - uses: Jimver/cuda-toolkit@v0.2.10
+        if: matrix.os == 'windows-latest'
+        id: cuda-toolkit-windows
+        with:
+          cuda: '12.1.0'
+          method: 'network'
+          sub-packages: '["nvcc","cudart","visual_studio_integration","cublas_dev"]'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Check
+        run: cargo check --verbose
+      - name: Build
+        run: cargo build --verbose --features cublas
+
+  opencl:
+    name: Build with opencl support
+    strategy:
+    # Don't stop building if it fails on an OS
+      fail-fast: false
+      matrix:
+        # TODO Add windows opencl build
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps: 
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install clblast
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install libclblast-dev 
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Check
+        run: cargo check --verbose
+      - name: Build
+        run: cargo build --verbose --features clblast

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,39 +60,39 @@ jobs:
     - name: Build
       run: cargo build --verbose --features metal
 
-  cuda:
-    name: Build with cuda support
-    strategy:
-    # Don't stop building if it fails on an OS
-      fail-fast: false
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    steps: 
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      - uses: Jimver/cuda-toolkit@v0.2.10
-        if: matrix.os == 'ubuntu-latest'
-        id: cuda-toolkit-linux
-        with:
-          cuda: '12.1.0'
-          method: 'network'
-          #See e.g. https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
-          sub-packages: '["nvcc","compiler","libraries","libraries-dev","cudart","cudart-dev","libcublas","libcublas-dev"]'
-      - uses: Jimver/cuda-toolkit@v0.2.10
-        if: matrix.os == 'windows-latest'
-        id: cuda-toolkit-windows
-        with:
-          cuda: '12.1.0'
-          method: 'network'
-          #See https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software
-          sub-packages: '["nvcc","cudart","visual_studio_integration","cublas_dev","cublas"]'
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Check
-        run: cargo check --verbose
-      - name: Build
-        run: cargo build --verbose --features cublas
+  # cuda:
+  #   name: Build with cuda support
+  #   strategy:
+  #   # Don't stop building if it fails on an OS
+  #     fail-fast: false
+  #     matrix:
+  #       os: [windows-latest, ubuntu-latest]
+  #   runs-on: ${{ matrix.os }}
+  #   steps: 
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         submodules: recursive
+  #     - uses: Jimver/cuda-toolkit@v0.2.10
+  #       if: matrix.os == 'ubuntu-latest'
+  #       id: cuda-toolkit-linux
+  #       with:
+  #         cuda: '12.1.0'
+  #         method: 'network'
+  #         #See e.g. https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
+  #         sub-packages: '["nvcc","compiler","libraries","libraries-dev","cudart","cudart-dev","libcublas","libcublas-dev"]'
+  #     - uses: Jimver/cuda-toolkit@v0.2.10
+  #       if: matrix.os == 'windows-latest'
+  #       id: cuda-toolkit-windows
+  #       with:
+  #         cuda: '12.1.0'
+  #         method: 'network'
+  #         #See https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software
+  #         sub-packages: '["nvcc","cudart","visual_studio_integration","cublas_dev","cublas"]'
+  #     - uses: dtolnay/rust-toolchain@stable
+  #     - name: Check
+  #       run: cargo check --verbose
+  #     - name: Build
+  #       run: cargo build --verbose --features cublas
 
   opencl:
     name: Build with opencl support

--- a/crates/ggml/sys/build.rs
+++ b/crates/ggml/sys/build.rs
@@ -155,6 +155,8 @@ fn lib_path(prefix: &str) -> String {
 fn enable_clblast(build: &mut cc::Build) {
     println!("cargo:rustc-link-lib=clblast");
     println!("cargo:rustc-link-lib=OpenCL");
+    //enable dynamic linking against stdc++
+    println!(r"cargo:rustc-link-lib=dylib=stdc++");
 
     build.file("llama-cpp/ggml-opencl.cpp");
     build.flag("-DGGML_USE_CLBLAST");


### PR DESCRIPTION
Closes https://github.com/rustformers/llm/issues/342.

Adds CI for metal/cuda and clblast builds to ensure they can be built. 