### PR TITLE
Use llm_samplers crate for sampler backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,6 +1285,7 @@ dependencies = [
  "bytemuck",
  "ggml",
  "half",
+ "llm-samplers",
  "memmap2",
  "partial_sort",
  "rand",
@@ -1314,6 +1315,7 @@ dependencies = [
  "env_logger",
  "is-terminal",
  "llm",
+ "llm-samplers",
  "log",
  "num_cpus",
  "rand",
@@ -1371,6 +1373,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "llm-samplers"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb5ff99b934436bd5ff7d1cdc3a674bf5b99ab996f36214306b2565cf393872"
+dependencies = [
+ "anyhow",
+ "num-traits",
+ "rand",
+ "thiserror",
+]
+
+[[package]]
 name = "llm-test"
 version = "0.2.0-dev"
 dependencies = [
@@ -1379,6 +1393,7 @@ dependencies = [
  "env_logger",
  "indicatif",
  "llm",
+ "llm-samplers",
  "log",
  "rand",
  "reqwest",
@@ -1569,6 +1584,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "llm-samplers"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb5ff99b934436bd5ff7d1cdc3a674bf5b99ab996f36214306b2565cf393872"
+checksum = "7553f60d113c9cdc6a5402456a31cd9a273bef79f6f16d8a4f7b4bedf5f754b2"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ clap = { version = "4.1.8", features = ["derive"] }
 memmap2 = "0.5.10"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1", features = ["log"] }
+llm-samplers = "=0.0.5"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ clap = { version = "4.1.8", features = ["derive"] }
 memmap2 = "0.5.10"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1", features = ["log"] }
-llm-samplers = "=0.0.5"
+llm-samplers = "=0.0.6"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/binaries/llm-cli/Cargo.toml
+++ b/binaries/llm-cli/Cargo.toml
@@ -35,6 +35,8 @@ tracing-appender = "0.2.2"
 # Remove this once we bump our MSRV to 1.70.
 is-terminal = "0.4"
 
+llm-samplers = { workspace = true }
+
 [dev-dependencies]
 rusty-hook = "^0.11.2"
 

--- a/binaries/llm-cli/src/interactive.rs
+++ b/binaries/llm-cli/src/interactive.rs
@@ -125,7 +125,7 @@ fn initialize_common_state(
     let model = model_load.load(generate.use_gpu)?;
     Ok((
         generate.inference_session_config(),
-        generate.inference_parameters(model.eot_token_id(), model.tokenizer().len()),
+        generate.inference_parameters(model.eot_token_id(), model.tokenizer().len())?,
         model,
         generate.rng(),
     ))

--- a/binaries/llm-cli/src/interactive.rs
+++ b/binaries/llm-cli/src/interactive.rs
@@ -125,7 +125,7 @@ fn initialize_common_state(
     let model = model_load.load(generate.use_gpu)?;
     Ok((
         generate.inference_session_config(),
-        generate.inference_parameters(model.eot_token_id()),
+        generate.inference_parameters(model.eot_token_id(), model.tokenizer().len()),
         model,
         generate.rng(),
     ))

--- a/binaries/llm-cli/src/main.rs
+++ b/binaries/llm-cli/src/main.rs
@@ -47,7 +47,9 @@ fn infer(args: &cli_args::Infer) -> eyre::Result<()> {
         args.load_session.as_deref(),
         inference_session_config,
     );
-    let parameters = args.generate.inference_parameters(model.eot_token_id());
+    let parameters = args
+        .generate
+        .inference_parameters(model.eot_token_id(), model.tokenizer().len());
 
     let mut rng = args.generate.rng();
 
@@ -93,6 +95,9 @@ fn infer(args: &cli_args::Infer) -> eyre::Result<()> {
             }
             Err(llm::InferenceError::TokenizationFailed(err)) => {
                 log::error!("A tokenization-related failure occurred: {}", err);
+            }
+            Err(llm::InferenceError::SamplerFailure(err)) => {
+                log::error!("A sampling-related failure occurred: {}", err);
             }
             Err(llm::InferenceError::UserCallback(_)) | Err(llm::InferenceError::EndOfText) => {
                 unreachable!("cannot fail")

--- a/binaries/llm-cli/src/main.rs
+++ b/binaries/llm-cli/src/main.rs
@@ -49,7 +49,7 @@ fn infer(args: &cli_args::Infer) -> eyre::Result<()> {
     );
     let parameters = args
         .generate
-        .inference_parameters(model.eot_token_id(), model.tokenizer().len());
+        .inference_parameters(model.eot_token_id(), model.tokenizer().len())?;
 
     let mut rng = args.generate.rng();
 

--- a/binaries/llm-test/Cargo.toml
+++ b/binaries/llm-test/Cargo.toml
@@ -17,6 +17,7 @@ clap = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
+llm-samplers = { workspace = true }
 
 reqwest = "0.11.9"
 indicatif = "0.16.2"

--- a/crates/llm-base/Cargo.toml
+++ b/crates/llm-base/Cargo.toml
@@ -26,6 +26,8 @@ tokenizers = {version="0.13.3", default-features=false, features=["onig"]}
 regex = "1.8"
 tracing = { workspace = true }
 
+llm-samplers = { workspace = true }
+
 [features]
 tokenizers-remote = ["tokenizers/http"]
 cublas = ["ggml/cublas"]

--- a/crates/llm-base/src/inference_session.rs
+++ b/crates/llm-base/src/inference_session.rs
@@ -695,7 +695,7 @@ pub enum InferenceError {
     UserCallback(Box<dyn std::error::Error + Send + Sync>),
     /// Sampling returned an error.
     #[error("token sampling failed")]
-    SamplerFailure(Box<dyn std::error::Error + Send + Sync>),
+    SamplerFailure(crate::samplers::SamplingError),
 }
 
 #[derive(Error, Debug)]

--- a/crates/llm-base/src/inference_session.rs
+++ b/crates/llm-base/src/inference_session.rs
@@ -385,7 +385,13 @@ impl InferenceSession {
             return Err(InferenceError::ContextFull);
         }
 
-        let next_token = params.sampler.sample(&self.tokens, &self.last_logits, rng);
+        let next_token = crate::samplers::sample_token(
+            params.sampler.clone(),
+            rng,
+            &self.tokens,
+            self.last_logits.iter().copied(),
+        )
+        .map_err(InferenceError::SamplerFailure)?;
 
         // Update the tokens for this session
         self.tokens.push(next_token);
@@ -687,6 +693,9 @@ pub enum InferenceError {
     #[error("the user-specified callback returned an error")]
     /// The user-specified callback returned an error.
     UserCallback(Box<dyn std::error::Error + Send + Sync>),
+    /// Sampling returned an error.
+    #[error("token sampling failed")]
+    SamplerFailure(Box<dyn std::error::Error + Send + Sync>),
 }
 
 #[derive(Error, Debug)]

--- a/crates/llm-base/src/lib.rs
+++ b/crates/llm-base/src/lib.rs
@@ -17,7 +17,7 @@ pub mod model;
 pub mod samplers;
 pub mod util;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 pub use ggml;
 pub use ggml::Type as ElementType;
@@ -28,6 +28,7 @@ pub use inference_session::{
     InferenceSessionConfig, InferenceSnapshot, InferenceSnapshotRef, InferenceStats,
     ModelKVMemoryType, RewindError, SnapshotError,
 };
+pub use llm_samplers::prelude::{Sampler, SamplerChain};
 pub use loader::{
     load, load_progress_callback_stdout, ContainerType, FileType, FileTypeFormat, FormatMagic,
     LoadError, LoadProgress, Loader, TensorLoader,
@@ -37,7 +38,6 @@ pub use memmap2::Mmap;
 pub use model::{Hyperparameters, KnownModel, Model, ModelParameters, OutputRequest};
 pub use quantize::{quantize, QuantizeError, QuantizeProgress};
 pub use regex::Regex;
-pub use samplers::Sampler;
 pub use tokenizer::{
     InvalidTokenBias, Prompt, TokenBias, TokenId, TokenizationError, Tokenizer, TokenizerLoadError,
     TokenizerSource,
@@ -57,9 +57,10 @@ pub struct InferenceParameters {
     /// from this distribution to generate the next token. Using a different sampler may
     /// change the output of the model, or control how deterministic the generated text is.
     ///
-    /// A recommended default sampler is [TopPTopK](samplers::TopPTopK), which is a standard
-    /// sampler that offers a [Default](samplers::TopPTopK::default) implementation.
-    pub sampler: Arc<dyn Sampler>,
+    /// This can be anything that implements [Sampler]. Refer to
+    /// the `llm-samplers` documentation for possible samplers and suggested
+    /// combinations: <https://docs.rs/llm-samplers>
+    pub sampler: Arc<Mutex<dyn Sampler<TokenId, f32>>>,
 }
 
 //Since Sampler implements Send and Sync, InferenceParameters should too.
@@ -68,8 +69,10 @@ unsafe impl Sync for InferenceParameters {}
 
 impl Default for InferenceParameters {
     fn default() -> Self {
+        let chain: SamplerChain<TokenId, f32> =
+            crate::samplers::ConfiguredSamplers::default().into();
         Self {
-            sampler: Arc::new(samplers::TopPTopK::default()),
+            sampler: Arc::new(Mutex::new(chain)),
         }
     }
 }

--- a/crates/llm-base/src/lib.rs
+++ b/crates/llm-base/src/lib.rs
@@ -69,10 +69,8 @@ unsafe impl Sync for InferenceParameters {}
 
 impl Default for InferenceParameters {
     fn default() -> Self {
-        let chain: SamplerChain<TokenId, f32> =
-            crate::samplers::ConfiguredSamplers::default().into();
         Self {
-            sampler: Arc::new(Mutex::new(chain)),
+            sampler: samplers::default_samplers(),
         }
     }
 }

--- a/crates/llm-base/src/samplers.rs
+++ b/crates/llm-base/src/samplers.rs
@@ -1,162 +1,306 @@
-//! Defines the samplers used for generation.
-//!
-//! You can define your own [Sampler] by implementing the trait.
+//! Types and methods used for constructing and running
+//! the samplers used for generation.
 
-use std::fmt::Debug;
+use std::{
+    error::Error,
+    fmt,
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
 
-use partial_sort::PartialSort;
-use rand::{distributions::WeightedIndex, prelude::Distribution};
+use llm_samplers::prelude::*;
 
-use crate::{TokenBias, TokenId};
+use crate::TokenId;
 
-/// A sampler for generation.
-pub trait Sampler: Debug + Send + Sync {
-    /// Given the previous tokens, the logits from the most recent evaluation, and a source of randomness,
-    /// sample from the logits and return the token ID.
-    fn sample(
-        &self,
-        previous_tokens: &[TokenId],
-        logits: &[f32],
-        rng: &mut dyn rand::RngCore,
-    ) -> TokenId;
+/// This structure holds specific samplers that have already
+/// been configured and provides some convenience methods
+/// for constructing samplers with default settings.
+#[derive(Debug, Default, Clone)]
+pub struct ConfiguredSamplers {
+    bias: Option<SampleFlatBias<TokenId, f32>>,
+    repetition: Option<SampleRepetition<TokenId, f32>>,
+    freq_presence: Option<SampleFreqPresence<TokenId, f32>>,
+    top_k: Option<SampleTopK>,
+    tail_free: Option<SampleTailFree<f32>>,
+    locally_typical: Option<SampleLocallyTypical<f32>>,
+    top_p: Option<SampleTopP<f32>>,
+    temperature: Option<SampleTemperature<f32>>,
+    mirostat1: Option<SampleMirostat1<TokenId, f32>>,
+    mirostat2: Option<SampleMirostat2<TokenId, f32>>,
 }
 
-/// Top-P Top-K sampling.
-///
-/// A standard sampler that uses top-K sampling (the top-K tokens with the highest
-/// probability are considered) and top-P sampling (only tokens with a cumulative
-/// probability of `P` are considered).
-///
-/// It also implements [CTRL](https://arxiv.org/abs/1909.05858)'s repetition penalty,
-/// and the ability to bias the generation of individual tokens.
-#[derive(Clone, Debug)]
-pub struct TopPTopK {
-    /// The top K words by score are kept during sampling.
-    pub top_k: usize,
-    /// The cumulative probability after which no more words are kept for sampling.
-    pub top_p: f32,
-    /// The penalty for repeating tokens. Higher values make the generation less
-    /// likely to get into a loop, but may harm results when repetitive outputs
-    /// are desired.
-    pub repeat_penalty: f32,
-    /// Temperature (randomness) used for sampling. A higher number is more random.
-    pub temperature: f32,
-    /// A list of tokens to bias against in the process of generation.
-    pub bias_tokens: TokenBias,
-    /// The number of tokens to consider for the repetition penalty.
-    pub repetition_penalty_last_n: usize,
-}
-impl Default for TopPTopK {
-    fn default() -> Self {
-        Self {
-            top_k: 40,
-            top_p: 0.95,
-            repeat_penalty: 1.30,
-            temperature: 0.80,
-            bias_tokens: TokenBias::empty(),
-            repetition_penalty_last_n: 512,
-        }
+impl ConfiguredSamplers {
+    /// Sets the token bias list
+    pub fn set_token_bias(&mut self, bias: impl IntoIterator<Item = (TokenId, f32)>) {
+        self.bias = Some(SampleFlatBias::new(bias))
+    }
+
+    /// Creates a temperature new sampler with default options.
+    pub fn new_temperature() -> SampleTemperature<f32> {
+        SampleTemperature::default().temperature(0.8)
+    }
+
+    /// Creates a new repetition sampler with default options.
+    pub fn new_repetition() -> SampleRepetition<TokenId, f32> {
+        SampleRepetition::default().penalty(1.30).last_n(64)
+    }
+
+    /// Creates a new frequency/presence sampler with default options.
+    pub fn new_freq_presence() -> SampleFreqPresence<TokenId, f32> {
+        SampleFreqPresence::default()
+            .frequency(0.0)
+            .presence(0.0)
+            .last_n(64)
+    }
+
+    /// Creates a new top k sampler with default options.
+    pub fn new_top_k() -> SampleTopK {
+        SampleTopK::default().k(40)
+    }
+
+    /// Creates a new top p sampler with default options.
+    pub fn new_top_p() -> SampleTopP<f32> {
+        SampleTopP::default().p(0.95)
+    }
+
+    /// Creates a new tail free sampler with default options.
+    pub fn new_tail_free() -> SampleTailFree<f32> {
+        SampleTailFree::default().z(1.0)
+    }
+
+    /// Creates a new locally typical sampler with default options.
+    pub fn new_locally_typical() -> SampleLocallyTypical<f32> {
+        SampleLocallyTypical::default().p(1.0)
+    }
+
+    /// Creates a new mirostat 1 sampler with default options.
+    pub fn new_mirostat1() -> SampleMirostat1<TokenId, f32> {
+        SampleMirostat1::default().eta(0.1).tau(5.0)
+    }
+
+    /// Creates a new mirostat 2 sampler with default options.
+    pub fn new_mirostat2() -> SampleMirostat2<TokenId, f32> {
+        SampleMirostat2::default().eta(0.1).tau(5.0)
     }
 }
-impl Sampler for TopPTopK {
-    fn sample(
-        &self,
-        previous_tokens: &[TokenId],
-        logits: &[f32],
-        rng: &mut dyn rand::RngCore,
-    ) -> TokenId {
-        let Self {
-            top_k,
-            top_p,
-            repeat_penalty,
-            temperature,
-            repetition_penalty_last_n,
-            ..
-        } = *self;
-        let bias_tokens = &self.bias_tokens;
 
-        let n_logits = logits.len();
-        let mut logits_id = Vec::<(f32, TokenId)>::with_capacity(n_logits);
+impl From<ConfiguredSamplers> for SamplerChain<TokenId, f32> {
+    fn from(val: ConfiguredSamplers) -> Self {
+        let mut chain = SamplerChain::new();
 
-        // TODO: consider if this can be modularized and this sampler can be composed out of multiple pieces,
-        // instead of having this monolithic function that embeds the repetition penalty and token bias
-        {
-            let scale = 1.0 / temperature;
-            for (i, &logit) in logits.iter().enumerate() {
-                let tid = i as TokenId;
+        if let Some(sampler) = val.bias {
+            chain += sampler;
+        }
+        if let Some(sampler) = val.repetition {
+            chain += sampler;
+        }
+        if let Some(sampler) = val.freq_presence {
+            chain += sampler;
+        }
 
-                let val = if let Some(logit_override) = bias_tokens.get(tid) {
-                    logit_override
-                } else if previous_tokens[previous_tokens
-                    .len()
-                    .saturating_sub(repetition_penalty_last_n)..]
-                    .contains(&(i as TokenId))
-                {
-                    // repetition penalty from CTRL paper (https://arxiv.org/abs/1909.05858)
-                    // credit https://github.com/facebookresearch/llama/compare/main...shawwn:llama:main
-
-                    // if score < 0 then repetition penalty has to multiplied to reduce the previous token probability
-                    if logits[i] < 0.0 {
-                        logit * scale * repeat_penalty
-                    } else {
-                        logit * scale / repeat_penalty
-                    }
-                } else {
-                    logit * scale
-                };
-                logits_id.push((val, tid));
+        if let Some(mirosampler) = val.mirostat1 {
+            if let Some(sampler) = val.temperature {
+                chain += sampler;
             }
-        }
-
-        // find the top K tokens
-        {
-            logits_id.partial_sort(top_k, |a, b| {
-                // Sort descending
-                b.0.total_cmp(&a.0)
-            });
-            logits_id.truncate(top_k);
-        }
-
-        let maxl = logits_id
-            .iter()
-            .map(|x| x.0)
-            .max_by(f32::total_cmp)
-            .unwrap();
-
-        // compute probs for the top K tokens
-        let mut probs: Vec<f32> = logits_id
-            .iter()
-            .copied()
-            .map(|(k, _)| (k - maxl).exp())
-            .collect();
-        let sum: f32 = probs.iter().copied().sum();
-
-        // Normalize the probs
-        for p in probs.iter_mut() {
-            *p /= sum;
-        }
-
-        // Top p sampling
-        if top_p < 1.0 {
-            let mut cumsum = 0.0;
-            for i in 0..probs.len() {
-                cumsum += probs[i];
-                if cumsum >= top_p {
-                    probs.truncate(i + 1);
-                    logits_id.truncate(i + 1);
-                    break;
-                }
+            chain += mirosampler;
+            return chain;
+        } else if let Some(mirosampler) = val.mirostat2 {
+            if let Some(sampler) = val.temperature {
+                chain += sampler;
             }
-
-            cumsum = 1.0 / cumsum;
-            for p in probs.iter_mut() {
-                *p *= cumsum;
-            }
+            chain += mirosampler;
+            return chain;
         }
 
-        let dist = WeightedIndex::new(&probs).expect("WeightedIndex error");
-        let idx = dist.sample(rng);
+        if let Some(sampler) = val.top_k {
+            chain += sampler;
+        }
+        if let Some(sampler) = val.tail_free {
+            chain += sampler;
+        }
+        if let Some(sampler) = val.locally_typical {
+            chain += sampler;
+        }
+        if let Some(sampler) = val.top_p {
+            chain += sampler;
+        }
+        if let Some(sampler) = val.temperature {
+            chain += sampler;
+        }
+        chain += SampleRandDistrib::new();
+        chain
+    }
+}
 
-        logits_id[idx].1
+impl ConfiguredSamplers {
+    fn from_args(args: Vec<ConfiguredSampler>, n_vocab: usize) -> Self {
+        let mut result = Self::default();
+
+        args.into_iter().for_each(|arg| match arg {
+            ConfiguredSampler::Repetition(sampler) => result.repetition = Some(sampler),
+            ConfiguredSampler::FreqPresence(sampler) => result.freq_presence = Some(sampler),
+            ConfiguredSampler::TopK(sampler) => result.top_k = Some(sampler),
+            ConfiguredSampler::TailFree(sampler) => result.tail_free = Some(sampler),
+            ConfiguredSampler::LocallyTypical(sampler) => result.locally_typical = Some(sampler),
+            ConfiguredSampler::TopP(sampler) => result.top_p = Some(sampler),
+            ConfiguredSampler::Temperature(sampler) => result.temperature = Some(sampler),
+            ConfiguredSampler::Mirostat1(sampler) => {
+                result.mirostat1 = Some(sampler.n_vocab(n_vocab))
+            }
+            ConfiguredSampler::Mirostat2(sampler) => result.mirostat2 = Some(sampler),
+        });
+
+        if result.temperature.is_none() {
+            result.temperature = Some(ConfiguredSamplers::new_temperature())
+        }
+        if result.repetition.is_none() {
+            result.repetition = Some(ConfiguredSamplers::new_repetition())
+        }
+        if result.mirostat1.is_some() || result.mirostat2.is_some() {
+            return result;
+        }
+
+        if result.top_k.is_none() {
+            result.top_k = Some(ConfiguredSamplers::new_top_k())
+        }
+        if result.top_p.is_none() {
+            result.top_p = Some(ConfiguredSamplers::new_top_p())
+        }
+        result
+    }
+}
+
+/// A specific type of sampler that has been configured
+#[derive(Clone, Debug)]
+pub enum ConfiguredSampler {
+    /// Holds the configured sampler
+    Repetition(SampleRepetition<TokenId, f32>),
+    /// Holds the configured sampler
+    FreqPresence(SampleFreqPresence<TokenId, f32>),
+    /// Holds the configured sampler
+    TopK(SampleTopK),
+    /// Holds the configured sampler
+    TailFree(SampleTailFree<f32>),
+    /// Holds the configured sampler
+    LocallyTypical(SampleLocallyTypical<f32>),
+    /// Holds the configured sampler
+    TopP(SampleTopP<f32>),
+    /// Holds the configured sampler
+    Temperature(SampleTemperature<f32>),
+    /// Holds the configured sampler
+    Mirostat1(SampleMirostat1<TokenId, f32>),
+    /// Holds the configured sampler
+    Mirostat2(SampleMirostat2<TokenId, f32>),
+}
+
+impl FromStr for ConfiguredSampler {
+    type Err = Box<dyn Error + Send + Sync + 'static>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (name, args) = if let Some(val) = s.split_once(':') {
+            val
+        } else {
+            return Err(Box::from("Bad format for sampler argument"));
+        };
+
+        Ok(match name.trim() {
+            "repetition" => ConfiguredSamplers::new_repetition()
+                .configure(args)
+                .map(Self::Repetition)?,
+            "frequency" | "presence" | "freqpresence" => ConfiguredSamplers::new_freq_presence()
+                .configure(args)
+                .map(Self::FreqPresence)?,
+            "topk" | "top_k" => {
+                ConfigurableSampler::<_, f32>::configure(ConfiguredSamplers::new_top_k(), args)
+                    .map(Self::TopK)?
+            }
+            "topp" | "top_p" => ConfiguredSamplers::new_top_p()
+                .configure(args)
+                .map(Self::TopP)?,
+            "temperature" | "temp" => ConfigurableSampler::<TokenId, _>::configure(
+                ConfiguredSamplers::new_temperature(),
+                args,
+            )
+            .map(Self::Temperature)?,
+            "tailfree" | "tail_free" => ConfiguredSamplers::new_tail_free()
+                .configure(args)
+                .map(Self::TailFree)?,
+            "locallytypical" | "locally_typical" => ConfiguredSamplers::new_locally_typical()
+                .configure(args)
+                .map(Self::LocallyTypical)?,
+            "mirostat1" => ConfiguredSamplers::new_mirostat1()
+                .configure(args)
+                .map(Self::Mirostat1)?,
+            "mirostat2" => ConfiguredSamplers::new_mirostat2()
+                .configure(args)
+                .map(Self::Mirostat2)?,
+            unknown => return Err(Box::from(format!("Unknown sampler: {unknown}"))),
+        })
+    }
+}
+
+/// Sample a token. This convenience function handles building
+/// the sampler resources and logits objects the sampler needs.
+pub fn sample_token(
+    mut sampler: impl Sampler<TokenId, f32>,
+    rng: &mut impl rand::Rng,
+    previous_tokens: &[TokenId],
+    last_logits: impl IntoIterator<Item = f32>,
+) -> Result<TokenId, Box<dyn Error + Send + Sync>> {
+    Logits::try_from_iter(last_logits.into_iter())?
+        .sample_token(
+            &mut SamplerResources {
+                previous_tokens,
+                rng,
+            },
+            &mut sampler,
+        )?
+        .ok_or_else(|| Box::from("sampler did not return a token"))
+}
+
+/// Build a sampler with the supplied options, vocab size and token bias list.
+pub fn build_sampler(
+    n_vocab: usize,
+    bias: &[(TokenId, f32)],
+    args: Vec<ConfiguredSampler>,
+) -> Arc<Mutex<dyn Sampler<TokenId, f32>>> {
+    let mut settings = ConfiguredSamplers::from_args(args, n_vocab);
+    if !bias.is_empty() {
+        settings.set_token_bias(bias.iter().copied())
+    }
+    let chain: SamplerChain<TokenId, f32> = settings.into();
+    Arc::new(Mutex::new(chain))
+}
+
+// Struct used to temporarily hold resources for the `llm_samplers`
+// sampler.
+struct SamplerResources<'pt, 'r> {
+    previous_tokens: &'pt [TokenId],
+    rng: &'r mut dyn rand::RngCore,
+}
+
+impl<'pt, 'r> fmt::Debug for SamplerResources<'pt, 'r> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SamplerResources")
+            .field("previous_tokens", &self.previous_tokens)
+            .field("rng", &"<dyn RngCore>")
+            .finish()
+    }
+}
+
+impl<'pt, 'r> HasSamplerResources for SamplerResources<'pt, 'r> {
+    type TokenId = TokenId;
+
+    fn with_rng_mut(
+        &mut self,
+        fun: &mut dyn FnMut(&mut dyn rand::RngCore),
+    ) -> Result<(), SamplerError> {
+        fun(self.rng);
+        Ok(())
+    }
+
+    fn with_last_tokens(&self, fun: &mut dyn FnMut(&[Self::TokenId])) -> Result<(), SamplerError> {
+        fun(self.previous_tokens);
+        Ok(())
     }
 }

--- a/crates/llm-base/src/tokenizer/mod.rs
+++ b/crates/llm-base/src/tokenizer/mod.rs
@@ -298,6 +298,12 @@ impl TokenBias {
     }
 }
 
+impl From<TokenBias> for Vec<(TokenId, f32)> {
+    fn from(val: TokenBias) -> Self {
+        val.0
+    }
+}
+
 impl FromStr for TokenBias {
     type Err = InvalidTokenBias;
 

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -85,7 +85,7 @@ pub use llm_base::{
     InferenceParameters, InferenceRequest, InferenceResponse, InferenceSession,
     InferenceSessionConfig, InferenceSnapshot, InferenceSnapshotRef, InferenceStats,
     InvalidTokenBias, KnownModel, LoadError, LoadProgress, Loader, Model, ModelKVMemoryType,
-    ModelParameters, OutputRequest, Prompt, QuantizeError, QuantizeProgress, RewindError, Sampler,
+    ModelParameters, OutputRequest, Prompt, QuantizeError, QuantizeProgress, RewindError,
     SnapshotError, TokenBias, TokenId, TokenUtf8Buffer, TokenizationError, Tokenizer,
     TokenizerSource,
 };


### PR DESCRIPTION
**Warning**: This is very lightly tested (but appears to work).

This pull adds optional (and off by default) integration with my `llm-samplers` crate ( https://crates.io/crates/llm-samplers ) which supports building modular sampler chains and includes all the samplers that `llama.cpp` currently supports.

I tried to implement this in a non-invasive way.

The pull adds support for:

* Mirostat v1 and v2 samplers
* Locally typical sampling
* Tail free sampling
* Frequency and presence penalties

Of course it supports all the existing sampler types as well.

*Caveats*: Right now using Mirostat v1 is really awkward because it needs to know the model vocabulary size but it doesn't seem like that information is available at the time the samplers are constructed. I made it a commandline option, but it would obviously be a lot better if the right value was automatically supplied since we do have that information (eventually).

One thing I could use help with is tests for samplers. Not necessarily even code, just "Given X, Y, Z parameters to sampler A, we expect result B". `llm-samplers` _does_ pass all the tests from llama.cpp but I don't have much faith in this signifying everything works perfectly.

Closes #318