### PR TITLE
Add CI for cuda builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,26 +83,14 @@ jobs:
           non-cuda-sub-packages: '["libcublas","libcublas-dev"]'
           sub-packages: '["nvcc","compiler","libraries","libraries-dev","cudart","cudart-dev"]'
 
-
-      - name: Install CUDA Toolkit on Windows
+      - uses: Jimver/cuda-toolkit@v0.2.11
+        name: Install CUDA toolkit on Windows
         if: matrix.os == 'windows-latest'
-        run: |
-          choco install cuda --version=12.2.0.53625 -y
-          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2\bin" >> $GITHUB_PATH
-          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2" >> $CUDA_PATH
-          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2" >> $CUDA_PATH_V12_2
-        shell: pwsh
-
-          
-      # - uses: Jimver/cuda-toolkit@v0.2.11
-      #   name: Install CUDA toolkit on Windows
-        
-      #   id: cuda-toolkit-windows
-      #   with:
-      #     cuda: '12.2.0'
-      #     method: 'network'
-      #     #See https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software
-      #     sub-packages: '["nvcc","cudart","visual_studio_integration","cublas_dev","cublas"]'
+        id: cuda-toolkit-windows
+        with:
+          cuda: '12.2.0'
+          #See https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software
+          method: 'local'
       - uses: dtolnay/rust-toolchain@stable
       - name: Check
         run: cargo check --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,9 +79,9 @@ jobs:
         with:
           cuda: '12.2.0'
           method: 'network'
-          non-cuda-sub-packages: True
           #See e.g. https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
-          sub-packages: '["cuda-nvcc","cuda-compiler","cuda-libraries","cuda-libraries-dev","cuda-cudart","cuda-cudart-dev","libcublas","libcublas-dev"]'
+          non-cuda-sub-packages: '["libcublas","libcublas-dev"]'
+          sub-packages: '["nvcc","compiler","libraries","libraries-dev","cudart","cudart-dev"]'
       - uses: Jimver/cuda-toolkit@v0.2.11
         name: Install CUDA toolkit on Windows
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,15 +82,27 @@ jobs:
           #See e.g. https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
           non-cuda-sub-packages: '["libcublas","libcublas-dev"]'
           sub-packages: '["nvcc","compiler","libraries","libraries-dev","cudart","cudart-dev"]'
-      - uses: Jimver/cuda-toolkit@v0.2.11
-        name: Install CUDA toolkit on Windows
+
+
+      - name: Install CUDA Toolkit on Windows
         if: matrix.os == 'windows-latest'
-        id: cuda-toolkit-windows
-        with:
-          cuda: '12.2.0'
-          method: 'network'
-          #See https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software
-          sub-packages: '["nvcc","cudart","visual_studio_integration","cublas_dev","cublas"]'
+        run: |
+          choco install cuda --version=12.2.0.53625 -y
+          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2\bin" >> $GITHUB_PATH
+          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2" >> $CUDA_PATH
+          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2" >> $CUDA_PATH_V12_2
+        shell: pwsh
+
+          
+      # - uses: Jimver/cuda-toolkit@v0.2.11
+      #   name: Install CUDA toolkit on Windows
+        
+      #   id: cuda-toolkit-windows
+      #   with:
+      #     cuda: '12.2.0'
+      #     method: 'network'
+      #     #See https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software
+      #     sub-packages: '["nvcc","cudart","visual_studio_integration","cublas_dev","cublas"]'
       - uses: dtolnay/rust-toolchain@stable
       - name: Check
         run: cargo check --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,39 +60,42 @@ jobs:
     - name: Build
       run: cargo build --verbose --features metal
 
-  # cuda:
-  #   name: Build with cuda support
-  #   strategy:
-  #   # Don't stop building if it fails on an OS
-  #     fail-fast: false
-  #     matrix:
-  #       os: [windows-latest, ubuntu-latest]
-  #   runs-on: ${{ matrix.os }}
-  #   steps: 
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         submodules: recursive
-  #     - uses: Jimver/cuda-toolkit@v0.2.10
-  #       if: matrix.os == 'ubuntu-latest'
-  #       id: cuda-toolkit-linux
-  #       with:
-  #         cuda: '12.1.0'
-  #         method: 'network'
-  #         #See e.g. https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
-  #         sub-packages: '["nvcc","compiler","libraries","libraries-dev","cudart","cudart-dev","libcublas","libcublas-dev"]'
-  #     - uses: Jimver/cuda-toolkit@v0.2.10
-  #       if: matrix.os == 'windows-latest'
-  #       id: cuda-toolkit-windows
-  #       with:
-  #         cuda: '12.1.0'
-  #         method: 'network'
-  #         #See https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software
-  #         sub-packages: '["nvcc","cudart","visual_studio_integration","cublas_dev","cublas"]'
-  #     - uses: dtolnay/rust-toolchain@stable
-  #     - name: Check
-  #       run: cargo check --verbose
-  #     - name: Build
-  #       run: cargo build --verbose --features cublas
+  cuda:
+    name: Build with cuda support
+    strategy:
+    # Don't stop building if it fails on an OS
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps: 
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: Jimver/cuda-toolkit@v0.2.11
+        name: Install CUDA toolkit on Linux
+        if: matrix.os == 'ubuntu-latest'
+        id: cuda-toolkit-linux
+        with:
+          cuda: '12.2.0'
+          method: 'network'
+          non-cuda-sub-packages: True
+          #See e.g. https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
+          sub-packages: '["cuda-nvcc","cuda-compiler","cuda-libraries","cuda-libraries-dev","cuda-cudart","cuda-cudart-dev","libcublas","libcublas-dev"]'
+      - uses: Jimver/cuda-toolkit@v0.2.11
+        name: Install CUDA toolkit on Windows
+        if: matrix.os == 'windows-latest'
+        id: cuda-toolkit-windows
+        with:
+          cuda: '12.2.0'
+          method: 'network'
+          #See https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software
+          sub-packages: '["nvcc","cudart","visual_studio_integration","cublas_dev","cublas"]'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Check
+        run: cargo check --verbose
+      - name: Build
+        run: cargo build --verbose --features cublas
 
   opencl:
     name: Build with opencl support


### PR DESCRIPTION
Adds cublas builds to CI. 

Currently the cuda-toolkit setup on a windows runner takes ~15 min (see https://github.com/Jimver/cuda-toolkit/issues/253), maybe we should disable the the windows cuda ci for the time being? 