### PR TITLE
feat(model/clone): derive `Clone` for `Box<dyn Model>`

### DIFF
--- a/binaries/llm-test/src/main.rs
+++ b/binaries/llm-test/src/main.rs
@@ -196,7 +196,9 @@ async fn test_model(
         local_path: &'a Path,
     }
     impl<'a> llm::ModelArchitectureVisitor<anyhow::Result<()>> for TestVisitor<'a> {
-        fn visit<M: llm::KnownModel + 'static>(&mut self) -> anyhow::Result<()> {
+        fn visit<M: llm::KnownModel + 'static + std::clone::Clone>(
+            &mut self,
+        ) -> anyhow::Result<()> {
             let Self {
                 model_config,
                 test_config,

--- a/crates/ggml/src/tensor.rs
+++ b/crates/ggml/src/tensor.rs
@@ -9,6 +9,12 @@ pub struct Tensor {
     pub(crate) ctx: Weak<NonNull<sys::ggml_context>>,
 }
 
+impl Clone for Tensor {
+    fn clone(&self) -> Self {
+        self.share()
+    }
+}
+
 impl Tensor {
     /// Size of the `ggml_tensor` struct in bytes.
     ///

--- a/crates/llm-base/src/model/mod.rs
+++ b/crates/llm-base/src/model/mod.rs
@@ -127,8 +127,18 @@ pub trait Model: Send + Sync {
 
     /// Returns whether the model supports deleting tokens.
     fn supports_rewind(&self) -> bool;
+
+    /// Clone this model into a boxed trait object.
+    fn clone_boxed(&self) -> Box<dyn Model>;
 }
-impl<H: Hyperparameters, M: KnownModel<Hyperparameters = H>> Model for M {
+
+impl Clone for Box<dyn Model> {
+    fn clone(&self) -> Box<dyn Model> {
+        self.clone_boxed()
+    }
+}
+
+impl<H: Hyperparameters, M: KnownModel<Hyperparameters = H> + Clone + 'static> Model for M {
     fn start_session(&self, config: InferenceSessionConfig) -> InferenceSession {
         KnownModel::start_session(self, config)
     }
@@ -161,6 +171,10 @@ impl<H: Hyperparameters, M: KnownModel<Hyperparameters = H>> Model for M {
 
     fn supports_rewind(&self) -> bool {
         KnownModel::supports_rewind(self)
+    }
+
+    fn clone_boxed(&self) -> Box<dyn Model> {
+        Box::new(self.clone())
     }
 }
 

--- a/crates/llm-base/src/tokenizer/mod.rs
+++ b/crates/llm-base/src/tokenizer/mod.rs
@@ -105,6 +105,7 @@ impl TokenizerSource {
     }
 }
 
+#[derive(Clone)]
 /// Encapsulates the tokenizer for a model, and provides methods to tokenize text.
 pub enum Tokenizer {
     /// The vocabulary built-in to the model.

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -181,7 +181,7 @@ define_models!(
 /// Used to dispatch some code based on the model architecture.
 pub trait ModelArchitectureVisitor<R> {
     /// Visit a model architecture.
-    fn visit<M: KnownModel + 'static>(&mut self) -> R;
+    fn visit<M: KnownModel + Clone + 'static>(&mut self) -> R;
 }
 
 /// An unsupported model architecture was specified.
@@ -212,7 +212,7 @@ pub fn load_dynamic(
     params: ModelParameters,
     load_progress_callback: impl FnMut(LoadProgress),
 ) -> Result<Box<dyn Model>, LoadError> {
-    fn load_model<M: KnownModel + 'static>(
+    fn load_model<M: KnownModel + Clone + 'static>(
         path: &Path,
         tokenizer_source: TokenizerSource,
         params: ModelParameters,
@@ -239,7 +239,7 @@ pub fn load_dynamic(
     impl<'a, F: FnMut(LoadProgress)> ModelArchitectureVisitor<Result<Box<dyn Model>, LoadError>>
         for LoadVisitor<'a, F>
     {
-        fn visit<M: KnownModel + 'static>(&mut self) -> Result<Box<dyn Model>, LoadError> {
+        fn visit<M: KnownModel + Clone + 'static>(&mut self) -> Result<Box<dyn Model>, LoadError> {
             load_model::<M>(
                 self.path,
                 self.tokenizer_source.clone(),

--- a/crates/models/bloom/src/lib.rs
+++ b/crates/models/bloom/src/lib.rs
@@ -15,6 +15,7 @@ use llm_base::{
 ///
 /// # Safety
 /// This implements [Send] and [Sync] as it is immutable after construction.
+#[derive(Clone)]
 pub struct Bloom {
     // the context size ("memory") the model should use when evaluating a prompt
     context_size: usize,
@@ -454,6 +455,7 @@ impl llm_base::Hyperparameters for Hyperparameters {
     }
 }
 
+#[derive(Clone)]
 struct Layer {
     pub attention_norm: ggml::Tensor,
     pub attention_norm_b: ggml::Tensor,

--- a/crates/models/falcon/src/lib.rs
+++ b/crates/models/falcon/src/lib.rs
@@ -21,6 +21,7 @@ use llm_base::{
 ///
 /// # Safety
 /// This implements [Send] and [Sync] as it is immutable after construction.
+#[derive(Clone)]
 pub struct Falcon {
     // the context size ("memory") the model should use when evaluating a prompt
     context_size: usize,
@@ -407,6 +408,7 @@ impl llm_base::Hyperparameters for Hyperparameters {
     }
 }
 
+#[derive(Clone)]
 struct Layer {
     // normalization
     attention_norm: Tensor,

--- a/crates/models/gpt2/src/lib.rs
+++ b/crates/models/gpt2/src/lib.rs
@@ -15,6 +15,7 @@ use llm_base::{
 ///
 /// # Safety
 /// This implements [Send] and [Sync] as it is immutable after construction.
+#[derive(Clone)]
 pub struct Gpt2 {
     // the context size ("memory") the model should use when evaluating a prompt
     context_size: usize,
@@ -435,6 +436,7 @@ impl llm_base::Hyperparameters for Hyperparameters {
     }
 }
 
+#[derive(Clone)]
 struct Layer {
     // normalization
     ln_1_g: Tensor,

--- a/crates/models/gptj/src/lib.rs
+++ b/crates/models/gptj/src/lib.rs
@@ -15,6 +15,7 @@ use llm_base::{
 ///
 /// # Safety
 /// This implements [Send] and [Sync] as it is immutable after construction.
+#[derive(Clone)]
 pub struct GptJ {
     // the context size ("memory") the model should use when evaluating a prompt
     context_size: usize,
@@ -394,6 +395,7 @@ impl llm_base::Hyperparameters for Hyperparameters {
     }
 }
 
+#[derive(Clone)]
 struct Layer {
     // normalization
     ln_1_g: Tensor,

--- a/crates/models/gptneox/src/lib.rs
+++ b/crates/models/gptneox/src/lib.rs
@@ -16,6 +16,7 @@ use llm_base::{
 ///
 /// # Safety
 /// This implements [Send] and [Sync] as it is immutable after construction.
+#[derive(Clone)]
 pub struct GptNeoX {
     // the context size ("memory") the model should use when evaluating a prompt
     context_size: usize,
@@ -446,6 +447,7 @@ impl llm_base::Hyperparameters for Hyperparameters {
     }
 }
 
+#[derive(Clone)]
 struct Layer {
     // pre-normalization
     ln_1_g: Tensor,

--- a/crates/models/llama/src/lib.rs
+++ b/crates/models/llama/src/lib.rs
@@ -14,6 +14,7 @@ use llm_base::{
 ///
 /// # Safety
 /// This implements [Send] and [Sync] as it is immutable after construction.
+#[derive(Clone)]
 pub struct Llama {
     // the context size ("memory") the model should use when evaluating a prompt
     context_size: usize,
@@ -410,6 +411,7 @@ impl llm_base::Hyperparameters for Hyperparameters {
     }
 }
 
+#[derive(Clone)]
 struct Layer {
     attention_norm: ggml::Tensor,
 

--- a/crates/models/mpt/src/lib.rs
+++ b/crates/models/mpt/src/lib.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use ggml::Tensor;
 use llm_base::{
-    ggml::{self},
+    ggml,
     model::{common, HyperparametersWriteError},
     util, FileType, GraphOutputs, InferenceParameters, InferenceSession, InferenceSessionConfig,
     KnownModel, LoadError, ModelParameters, OutputRequest, Regex, TokenId, Tokenizer,
@@ -15,6 +15,7 @@ use llm_base::{
 ///
 /// # Safety
 /// This implements [Send] and [Sync] as it is immutable after construction.
+#[derive(Clone)]
 pub struct Mpt {
     // the context size ("memory") the model should use when evaluating a prompt
     context_size: usize,
@@ -367,6 +368,7 @@ impl llm_base::Hyperparameters for Hyperparameters {
     }
 }
 
+#[derive(Clone)]
 struct Layer {
     // pre normalization
     norm_1_weight: Tensor,


### PR DESCRIPTION
This builds on top of the work @louisgv did in #263.

This commit addresses the following scenario: for a service that is supposed to start multiple inference sessions based on the same model, the performance of loading the model on every request is (at least based on empirical evidence) not consistent.

This commit makes it possible to clone a model and create a new inferencing session without paying the cost of loading the model on every request.

The implementation ultimately implements `Clone` for `Tensor` by calling the `share` function.
The initial attempt does this because it reduces the `Clone` implementations for each model to deriving it, rather than having an explicit `impl` — the alternative would mean manually calling `share` for every layer and every tensor for the implemented models — happy to take this approach is it makes more sense.