### PR TITLE
Remove `repeat` operation and add acceleration support for other architectures

### DIFF
--- a/crates/ggml/src/accelerator/metal.rs
+++ b/crates/ggml/src/accelerator/metal.rs
@@ -83,7 +83,7 @@ impl MetalContext {
         unsafe {
             metal::ggml_metal_graph_compute(
                 self.ptr.as_ptr(),
-                &mut graph.inner as *mut ggml_sys::ggml_cgraph as *mut metal::ggml_cgraph,
+                graph.inner as *mut ggml_sys::ggml_cgraph as *mut metal::ggml_cgraph,
             );
         }
     }

--- a/crates/ggml/src/context.rs
+++ b/crates/ggml/src/context.rs
@@ -274,13 +274,13 @@ impl Context {
         self.new_tensor_raw(tensor)
     }
 
-    /// Creates a new tensor with the multiplication of `a` and `b`.
+    /// Creates a new tensor with the multiplication of `a` and `b`. Supports broadcasting if the dimensions are compatible, menaing the first dimensions of `a` must be devisible by the first dimensions of `b`.
     pub fn op_mul(&self, a: &Tensor, b: &Tensor) -> Tensor {
         let tensor = unsafe { sys::ggml_mul(self.as_ptr(), a.ptr.as_ptr(), b.ptr.as_ptr()) };
         self.new_tensor_raw(tensor)
     }
 
-    /// Unknown.
+    /// Repeats the `a` tensor along the first dimension of the `b` tensor.  
     pub fn op_repeat(&self, a: &Tensor, b: &Tensor) -> Tensor {
         let tensor = unsafe { sys::ggml_repeat(self.as_ptr(), a.ptr.as_ptr(), b.ptr.as_ptr()) };
         self.new_tensor_raw(tensor)
@@ -298,7 +298,7 @@ impl Context {
         self.new_tensor_raw(tensor)
     }
 
-    /// Creates a new tensor with the addition of `a` and `b`.
+    /// Creates a new tensor with the addition of `a` and `b`. Supports broadcasting if the dimensions are compatible, menaing the first dimensions of `a` must be devisible by the first dimensions of `b`.
     pub fn op_add(&self, a: &Tensor, b: &Tensor) -> Tensor {
         let tensor = unsafe { sys::ggml_add(self.as_ptr(), a.ptr.as_ptr(), b.ptr.as_ptr()) };
         self.new_tensor_raw(tensor)

--- a/crates/ggml/sys/src/cuda.rs
+++ b/crates/ggml/sys/src/cuda.rs
@@ -61,6 +61,9 @@ extern "C" {
     pub fn ggml_cuda_set_main_device(main_device: ::std::os::raw::c_int);
 }
 extern "C" {
+    pub fn ggml_cuda_set_mul_mat_q(mul_mat_q: bool);
+}
+extern "C" {
     pub fn ggml_cuda_set_scratch_size(scratch_size: usize);
 }
 extern "C" {

--- a/crates/ggml/sys/src/lib.rs
+++ b/crates/ggml/sys/src/lib.rs
@@ -1568,6 +1568,18 @@ extern "C" {
     ) -> *mut ggml_tensor;
 }
 extern "C" {
+    pub fn ggml_rope_custom(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        n_past: ::std::os::raw::c_int,
+        n_dims: ::std::os::raw::c_int,
+        mode: ::std::os::raw::c_int,
+        n_ctx: ::std::os::raw::c_int,
+        freq_base: f32,
+        freq_scale: f32,
+    ) -> *mut ggml_tensor;
+}
+extern "C" {
     pub fn ggml_rope_custom_inplace(
         ctx: *mut ggml_context,
         a: *mut ggml_tensor,

--- a/crates/llm-base/src/inference_session.rs
+++ b/crates/llm-base/src/inference_session.rs
@@ -170,7 +170,7 @@ impl InferenceSession {
             } else {
                 1024
             };
-            buf_size_mb * 1024 * 1024
+            buf_size_mb * 1024 * 1024 + ggml::graph_overhead()
         };
 
         let eval = Buffer::new(buf_size);

--- a/crates/llm-base/src/lora.rs
+++ b/crates/llm-base/src/lora.rs
@@ -114,7 +114,7 @@ impl LoraAdapter {
 
         //Build a ggml context and apply the patch
 
-        let mut gf = ggml::ComputationGraph::new();
+        let mut gf = patch_context.create_compute_graph();
 
         // LoRA formula: w = w + ba*s
         let mut ba = patch_context.op_mul_mat(&a, &b);

--- a/crates/models/bloom/src/lib.rs
+++ b/crates/models/bloom/src/lib.rs
@@ -145,8 +145,8 @@ impl KnownModel for Bloom {
 
             // normalize embeddings
             input_layer = ctx0.op_norm(&input_layer);
-            input_layer = ctx0.op_mul(&ctx0.op_repeat(&self.norm, &input_layer), &input_layer);
-            input_layer = ctx0.op_add(&ctx0.op_repeat(&self.norm_bias, &input_layer), &input_layer);
+            input_layer = ctx0.op_mul(&input_layer, &self.norm);
+            input_layer = ctx0.op_add(&input_layer, &self.norm_bias);
 
             let mut gf = ggml::ComputationGraph::new();
             for il in 0..n_layer {
@@ -157,21 +157,12 @@ impl KnownModel for Bloom {
                 current = ctx0.op_norm(&input_layer);
 
                 // cur = attention_norm * cur
-                current = ctx0.op_mul(
-                    &ctx0.op_repeat(&self.layers[il].attention_norm, &current),
-                    &current,
-                );
-                current = ctx0.op_add(
-                    &ctx0.op_repeat(&self.layers[il].attention_norm_b, &current),
-                    &current,
-                );
+                current = ctx0.op_mul(&current, &self.layers[il].attention_norm);
+                current = ctx0.op_add(&current, &self.layers[il].attention_norm_b);
 
                 //attention
                 current = ctx0.op_mul_mat(&self.layers[il].query_key_value, &current);
-                current = ctx0.op_add(
-                    &ctx0.op_repeat(&self.layers[il].query_key_value_b, &current),
-                    &current,
-                );
+                current = ctx0.op_add(&current, &self.layers[il].query_key_value_b);
 
                 // self-attention
                 let nb = current.get_nb()[1];
@@ -293,7 +284,7 @@ impl KnownModel for Bloom {
 
                 // projection
                 current = ctx0.op_mul_mat(&self.layers[il].wo, &current);
-                current = ctx0.op_add(&ctx0.op_repeat(&self.layers[il].wo_b, &current), &current);
+                current = ctx0.op_add(&current, &self.layers[il].wo_b);
 
                 let input_feed_forward = ctx0.op_add(&current, &input_self_attention);
 
@@ -302,19 +293,13 @@ impl KnownModel for Bloom {
                 current = ctx0.op_norm(&input_feed_forward);
 
                 // cur = ffn_norm*cur + ffn_norm_b
-                current = ctx0.op_mul(
-                    &ctx0.op_repeat(&self.layers[il].ffn_norm, &current),
-                    &current,
-                );
+                current = ctx0.op_mul(&current, &self.layers[il].ffn_norm);
 
-                current = ctx0.op_add(
-                    &ctx0.op_repeat(&self.layers[il].ffn_norm_b, &current),
-                    &current,
-                );
+                current = ctx0.op_add(&current, &self.layers[il].ffn_norm_b);
 
                 current = ctx0.op_mul_mat(&self.layers[il].w1, &current);
 
-                current = ctx0.op_add(&ctx0.op_repeat(&self.layers[il].w1_b, &current), &current);
+                current = ctx0.op_add(&current, &self.layers[il].w1_b);
 
                 // SILU activation
 
@@ -322,7 +307,7 @@ impl KnownModel for Bloom {
 
                 current = ctx0.op_mul_mat(&self.layers[il].w2, &current);
 
-                current = ctx0.op_add(&ctx0.op_repeat(&self.layers[il].w2_b, &current), &current);
+                current = ctx0.op_add(&current, &self.layers[il].w2_b);
 
                 current = ctx0.op_add(&current, &input_feed_forward);
 
@@ -334,15 +319,9 @@ impl KnownModel for Bloom {
             input_layer = ctx0.op_norm(&input_layer);
 
             // inpL = norm*inpL
-            input_layer = ctx0.op_mul(
-                &ctx0.op_repeat(&self.output_norm, &input_layer),
-                &input_layer,
-            );
+            input_layer = ctx0.op_mul(&input_layer, &self.output_norm);
 
-            input_layer = ctx0.op_add(
-                &ctx0.op_repeat(&self.output_norm_bias, &input_layer),
-                &input_layer,
-            );
+            input_layer = ctx0.op_add(&input_layer, &self.output_norm_bias);
 
             let embeddings_tensor: ggml::Tensor = input_layer.share();
 

--- a/crates/models/bloom/src/lib.rs
+++ b/crates/models/bloom/src/lib.rs
@@ -148,7 +148,7 @@ impl KnownModel for Bloom {
             input_layer = ctx0.op_mul(&input_layer, &self.norm);
             input_layer = ctx0.op_add(&input_layer, &self.norm_bias);
 
-            let mut gf = ggml::ComputationGraph::new();
+            let mut gf = ctx0.create_compute_graph();
             for il in 0..n_layer {
                 let input_self_attention = input_layer.share();
                 let mut current: ggml::Tensor;

--- a/crates/models/falcon/src/lib.rs
+++ b/crates/models/falcon/src/lib.rs
@@ -58,14 +58,19 @@ impl KnownModel for Falcon {
 
         // model-gobal weights
         let tok_embeddings = tl.load("transformer.word_embeddings.weight")?;
-        let output_norm = tl.load("transformer.ln_f.weight")?;
-        let output_norm_b = tl.load("transformer.ln_f.bias")?;
-        let lm_head = tl.load("lm_head.weight")?;
+
+        let backend = params.backend(0);
+
+        let output_norm = tl.load("transformer.ln_f.weight")?.transfer_to(backend);
+        let output_norm_b = tl.load("transformer.ln_f.bias")?.transfer_to(backend);
+        let lm_head = tl.load("lm_head.weight")?.transfer_to(backend);
 
         let mut layers = Vec::new();
         // utilizing n_head_kv to determine the model version (parameters)
         let Hyperparameters { n_head_kv, .. } = hyperparameters;
         for i in 0..hyperparameters.n_layer {
+            let backend = params.backend(i);
+
             let (input_layernorm_name, attention_norm_name) = if n_head_kv == 1 {
                 // falcon 7b
                 (format!("transformer.h.{i}.input_layernorm"), None)
@@ -76,24 +81,47 @@ impl KnownModel for Falcon {
                     Some(format!("transformer.h.{i}.ln_attn")),
                 )
             };
+
+            let (attention_norm_weight, attention_norm_bias) =
+                if let Some(norm_name) = attention_norm_name {
+                    (
+                        Some(
+                            tl.load(&format!("{}.weight", norm_name))?
+                                .transfer_to(backend),
+                        ),
+                        Some(
+                            tl.load(&format!("{}.bias", norm_name))?
+                                .transfer_to(backend),
+                        ),
+                    )
+                } else {
+                    (None, None)
+                };
+
             let layer = Layer {
-                input_layernorm: tl.load(&format!("{}.weight", input_layernorm_name))?,
-                input_layernorm_b: tl.load(&format!("{}.bias", input_layernorm_name))?,
-                attention_norm: attention_norm_name
-                    .as_ref()
-                    .map(|path| tl.load(&format!("{}.weight", path)))
-                    .transpose()?,
-                attention_norm_b: attention_norm_name
-                    .map(|path| tl.load(&format!("{}.bias", path)))
-                    .transpose()?,
+                input_layernorm: tl
+                    .load(&format!("{}.weight", input_layernorm_name))?
+                    .transfer_to(backend),
+                input_layernorm_b: tl
+                    .load(&format!("{}.bias", input_layernorm_name))?
+                    .transfer_to(backend),
+                attention_norm: attention_norm_weight,
+                attention_norm_b: attention_norm_bias,
+                query_key_value: tl
+                    .load(&format!(
+                        "transformer.h.{i}.self_attention.query_key_value.weight"
+                    ))?
+                    .transfer_to(backend),
+                wo: tl
+                    .load(&format!("transformer.h.{i}.self_attention.dense.weight"))?
+                    .transfer_to(backend),
 
-                query_key_value: tl.load(&format!(
-                    "transformer.h.{i}.self_attention.query_key_value.weight"
-                ))?,
-                wo: tl.load(&format!("transformer.h.{i}.self_attention.dense.weight"))?,
-
-                ffn_up: tl.load(&format!("transformer.h.{i}.mlp.dense_h_to_4h.weight"))?,
-                ffn_down: tl.load(&format!("transformer.h.{i}.mlp.dense_4h_to_h.weight"))?,
+                ffn_up: tl
+                    .load(&format!("transformer.h.{i}.mlp.dense_h_to_4h.weight"))?
+                    .transfer_to(backend),
+                ffn_down: tl
+                    .load(&format!("transformer.h.{i}.mlp.dense_4h_to_h.weight"))?
+                    .transfer_to(backend),
             };
 
             layers.push(layer);
@@ -147,7 +175,7 @@ impl KnownModel for Falcon {
         let n = input_len;
 
         let outputs = session.compute(self.context.clone(), input_tokens, |builder| {
-            let ctx0 = builder.ctx0.borrow();
+            let mut ctx0 = builder.ctx0.borrow_mut();
             let embd = builder.embd;
             let mut input_layer = ctx0.op_get_rows(&self.tok_embeddings, embd);
 
@@ -167,6 +195,7 @@ impl KnownModel for Falcon {
             for il in 0..n_layer {
                 // attention uses first scratch buffer
                 ctx0.use_scratch(builder.get_scratch(0));
+                ctx0.set_offloading(self.params.should_offload(il));
 
                 // self-attention
                 layernorm_output = ctx0.op_norm(&input_layer);
@@ -321,6 +350,7 @@ impl KnownModel for Falcon {
 
             let embeddings_tensor: ggml::Tensor = input_layer.share();
 
+            ctx0.set_offloading(false);
             ctx0.use_scratch(None);
 
             // lm_head

--- a/crates/models/falcon/src/lib.rs
+++ b/crates/models/falcon/src/lib.rs
@@ -171,11 +171,8 @@ impl KnownModel for Falcon {
                 // self-attention
                 layernorm_output = ctx0.op_norm(&input_layer);
                 layernorm_output = ctx0.op_add(
-                    &ctx0.op_mul(
-                        &ctx0.op_repeat(&self.layers[il].input_layernorm, &layernorm_output),
-                        &layernorm_output,
-                    ),
-                    &ctx0.op_repeat(&self.layers[il].input_layernorm_b, &layernorm_output),
+                    &ctx0.op_mul(&layernorm_output, &self.layers[il].input_layernorm),
+                    &self.layers[il].input_layernorm_b,
                 );
 
                 if n_head_kv == 1 {
@@ -185,17 +182,8 @@ impl KnownModel for Falcon {
                     // Falcon-40B only
                     current = ctx0.op_norm(&input_layer);
                     current = ctx0.op_add(
-                        &ctx0.op_mul(
-                            &ctx0.op_repeat(
-                                self.layers[il].attention_norm.as_ref().unwrap(),
-                                &current,
-                            ),
-                            &current,
-                        ),
-                        &ctx0.op_repeat(
-                            self.layers[il].attention_norm_b.as_ref().unwrap(),
-                            &current,
-                        ),
+                        &ctx0.op_mul(&current, self.layers[il].attention_norm.as_ref().unwrap()),
+                        self.layers[il].attention_norm_b.as_ref().unwrap(),
                     );
                 }
 
@@ -327,11 +315,8 @@ impl KnownModel for Falcon {
             input_layer = ctx0.op_norm(&input_layer);
 
             input_layer = ctx0.op_add(
-                &ctx0.op_mul(
-                    &ctx0.op_repeat(&self.output_norm, &input_layer),
-                    &input_layer,
-                ),
-                &ctx0.op_repeat(&self.output_norm_b, &input_layer),
+                &ctx0.op_mul(&input_layer, &self.output_norm),
+                &self.output_norm_b,
             );
 
             let embeddings_tensor: ggml::Tensor = input_layer.share();

--- a/crates/models/falcon/src/lib.rs
+++ b/crates/models/falcon/src/lib.rs
@@ -159,7 +159,7 @@ impl KnownModel for Falcon {
             let memory_v = builder.memory_v;
             let memory_v_size = memory_v.element_size();
 
-            let mut gf = ggml::ComputationGraph::new();
+            let mut gf = ctx0.create_compute_graph();
 
             let mut current: Tensor;
             let mut layernorm_output: Tensor;

--- a/crates/models/gpt2/src/lib.rs
+++ b/crates/models/gpt2/src/lib.rs
@@ -147,7 +147,7 @@ impl KnownModel for Gpt2 {
                 &ctx0.op_get_rows(&self.wpe, &position),
             );
 
-            let mut gf = ggml::ComputationGraph::new();
+            let mut gf = ctx0.create_compute_graph();
             for il in 0..n_layer {
                 ctx0.use_scratch(builder.get_scratch(0));
 

--- a/crates/models/gpt2/src/lib.rs
+++ b/crates/models/gpt2/src/lib.rs
@@ -56,10 +56,9 @@ impl KnownModel for Gpt2 {
         let mut tl = tensor_loader;
 
         // model-global weights
-        let wpe = tl.load("model/wpe")?;
-
         let backend = params.backend(0);
 
+        let wpe = tl.load("model/wpe")?.transfer_to(backend);
         let wte = tl.load("model/wte")?.transfer_to(backend);
 
         let ln_f_g = tl.load("model/ln_f/g")?.transfer_to(backend);

--- a/crates/models/gpt2/src/lib.rs
+++ b/crates/models/gpt2/src/lib.rs
@@ -154,16 +154,13 @@ impl KnownModel for Gpt2 {
                 // norm
                 let mut current = ctx0.op_norm(&input_layer);
                 current = ctx0.op_add(
-                    &ctx0.op_mul(&ctx0.op_repeat(&self.layers[il].ln_1_g, &current), &current),
-                    &ctx0.op_repeat(&self.layers[il].ln_1_b, &current),
+                    &ctx0.op_mul(&current, &self.layers[il].ln_1_g),
+                    &self.layers[il].ln_1_b,
                 );
 
                 // attn
                 current = ctx0.op_mul_mat(&self.layers[il].c_attn_attn_w, &current);
-                current = ctx0.op_add(
-                    &ctx0.op_repeat(&self.layers[il].c_attn_attn_b, &current),
-                    &current,
-                );
+                current = ctx0.op_add(&current, &self.layers[il].c_attn_attn_b);
 
                 // self-attn
                 let nb = current.get_nb()[1];
@@ -252,10 +249,7 @@ impl KnownModel for Gpt2 {
 
                 // projection
                 current = ctx0.op_mul_mat(&self.layers[il].c_attn_proj_w, &current);
-                current = ctx0.op_add(
-                    &ctx0.op_repeat(&self.layers[il].c_attn_proj_b, &current),
-                    &current,
-                );
+                current = ctx0.op_add(&current, &self.layers[il].c_attn_proj_b);
 
                 // add input
                 current = ctx0.op_add(&current, &input_layer);
@@ -268,26 +262,20 @@ impl KnownModel for Gpt2 {
                 // feed-forward normalization
                 current = ctx0.op_norm(&ff_in);
                 current = ctx0.op_add(
-                    &ctx0.op_mul(&ctx0.op_repeat(&self.layers[il].ln_2_g, &current), &current),
-                    &ctx0.op_repeat(&self.layers[il].ln_2_b, &current),
+                    &ctx0.op_mul(&current, &self.layers[il].ln_2_g),
+                    &self.layers[il].ln_2_b,
                 );
 
                 // feed-forward fully connected
                 current = ctx0.op_mul_mat(&self.layers[il].c_mlp_fc_w, &current);
-                current = ctx0.op_add(
-                    &ctx0.op_repeat(&self.layers[il].c_mlp_fc_b, &current),
-                    &current,
-                );
+                current = ctx0.op_add(&current, &self.layers[il].c_mlp_fc_b);
 
                 // feed-forward activation
                 current = ctx0.op_gelu(&current);
 
                 // feed-forward projection
                 current = ctx0.op_mul_mat(&self.layers[il].c_mlp_proj_w, &current);
-                current = ctx0.op_add(
-                    &ctx0.op_repeat(&self.layers[il].c_mlp_proj_b, &current),
-                    &current,
-                );
+                current = ctx0.op_add(&current, &self.layers[il].c_mlp_proj_b);
 
                 // input for next layer
                 input_layer = ctx0.op_add(&current, &ff_in);
@@ -297,10 +285,7 @@ impl KnownModel for Gpt2 {
 
             // normalization
             input_layer = ctx0.op_norm(&input_layer);
-            input_layer = ctx0.op_add(
-                &ctx0.op_mul(&ctx0.op_repeat(&self.ln_f_g, &input_layer), &input_layer),
-                &ctx0.op_repeat(&self.ln_f_b, &input_layer),
-            );
+            input_layer = ctx0.op_add(&ctx0.op_mul(&input_layer, &self.ln_f_g), &self.ln_f_b);
 
             ctx0.use_scratch(None);
 

--- a/crates/models/gptj/src/lib.rs
+++ b/crates/models/gptj/src/lib.rs
@@ -160,7 +160,7 @@ impl KnownModel for GptJ {
 
             let mut input_layer = ctx0.op_get_rows(&self.wte, embd);
 
-            let mut gf = ggml::ComputationGraph::new();
+            let mut gf = ctx0.create_compute_graph();
             for il in 0..n_layer {
                 ctx0.set_offloading(self.params.should_offload(il));
 

--- a/crates/models/gptj/src/lib.rs
+++ b/crates/models/gptj/src/lib.rs
@@ -57,24 +57,49 @@ impl KnownModel for GptJ {
 
         // model-global weights
         let wte = tl.load("transformer.wte.weight")?;
-        let ln_f_g = tl.load("transformer.ln_f.weight")?;
-        let ln_f_b = tl.load("transformer.ln_f.bias")?;
-        let lmh_g = tl.load("lm_head.weight")?;
-        let lmh_b = tl.load("lm_head.bias")?;
+
+        let backend = params.backend(0);
+
+        let ln_f_g = tl.load("transformer.ln_f.weight")?.transfer_to(backend);
+        let ln_f_b = tl.load("transformer.ln_f.bias")?.transfer_to(backend);
+        let lmh_g = tl.load("lm_head.weight")?.transfer_to(backend);
+        let lmh_b = tl.load("lm_head.bias")?.transfer_to(backend);
 
         let mut layers = Vec::new();
         for i in 0..hyperparameters.n_layer {
+            let backend = params.backend(i);
+
             let layer = Layer {
-                ln_1_g: tl.load(&format!("transformer.h.{i}.ln_1.weight"))?,
-                ln_1_b: tl.load(&format!("transformer.h.{i}.ln_1.bias"))?,
-                c_attn_q_proj_w: tl.load(&format!("transformer.h.{i}.attn.q_proj.weight"))?,
-                c_attn_k_proj_w: tl.load(&format!("transformer.h.{i}.attn.k_proj.weight"))?,
-                c_attn_v_proj_w: tl.load(&format!("transformer.h.{i}.attn.v_proj.weight"))?,
-                c_attn_proj_w: tl.load(&format!("transformer.h.{i}.attn.out_proj.weight"))?,
-                c_mlp_fc_w: tl.load(&format!("transformer.h.{i}.mlp.fc_in.weight"))?,
-                c_mlp_fc_b: tl.load(&format!("transformer.h.{i}.mlp.fc_in.bias"))?,
-                c_mlp_proj_w: tl.load(&format!("transformer.h.{i}.mlp.fc_out.weight"))?,
-                c_mlp_proj_b: tl.load(&format!("transformer.h.{i}.mlp.fc_out.bias"))?,
+                ln_1_g: tl
+                    .load(&format!("transformer.h.{i}.ln_1.weight"))?
+                    .transfer_to(backend),
+                ln_1_b: tl
+                    .load(&format!("transformer.h.{i}.ln_1.bias"))?
+                    .transfer_to(backend),
+                c_attn_q_proj_w: tl
+                    .load(&format!("transformer.h.{i}.attn.q_proj.weight"))?
+                    .transfer_to(backend),
+                c_attn_k_proj_w: tl
+                    .load(&format!("transformer.h.{i}.attn.k_proj.weight"))?
+                    .transfer_to(backend),
+                c_attn_v_proj_w: tl
+                    .load(&format!("transformer.h.{i}.attn.v_proj.weight"))?
+                    .transfer_to(backend),
+                c_attn_proj_w: tl
+                    .load(&format!("transformer.h.{i}.attn.out_proj.weight"))?
+                    .transfer_to(backend),
+                c_mlp_fc_w: tl
+                    .load(&format!("transformer.h.{i}.mlp.fc_in.weight"))?
+                    .transfer_to(backend),
+                c_mlp_fc_b: tl
+                    .load(&format!("transformer.h.{i}.mlp.fc_in.bias"))?
+                    .transfer_to(backend),
+                c_mlp_proj_w: tl
+                    .load(&format!("transformer.h.{i}.mlp.fc_out.weight"))?
+                    .transfer_to(backend),
+                c_mlp_proj_b: tl
+                    .load(&format!("transformer.h.{i}.mlp.fc_out.bias"))?
+                    .transfer_to(backend),
             };
 
             layers.push(layer);
@@ -126,7 +151,7 @@ impl KnownModel for GptJ {
         } = self.hyperparameters;
 
         let outputs = session.compute(self.context.clone(), input_tokens, |builder| {
-            let ctx0 = builder.ctx0.borrow();
+            let mut ctx0 = builder.ctx0.borrow_mut();
             let (memory_k_size, memory_v_size) = (
                 builder.memory_k.element_size(),
                 builder.memory_v.element_size(),
@@ -137,6 +162,8 @@ impl KnownModel for GptJ {
 
             let mut gf = ggml::ComputationGraph::new();
             for il in 0..n_layer {
+                ctx0.set_offloading(self.params.should_offload(il));
+
                 // norm
                 let mut current = ctx0.op_norm(&input_layer);
                 current = ctx0.op_add(
@@ -263,6 +290,9 @@ impl KnownModel for GptJ {
 
             // lm_head
             input_layer = ctx0.op_mul_mat(&self.lmh_g, &input_layer);
+
+            ctx0.set_offloading(false);
+
             input_layer = ctx0.op_add(&input_layer, &self.lmh_b);
 
             (

--- a/crates/models/llama/src/lib.rs
+++ b/crates/models/llama/src/lib.rs
@@ -144,7 +144,7 @@ impl KnownModel for Llama {
 
             let mut input_layer = ctx0.op_get_rows(&self.wte, embd);
 
-            let mut gf = ggml::ComputationGraph::new();
+            let mut gf = ctx0.create_compute_graph();
 
             for il in 0..n_layer {
                 ctx0.set_offloading(self.params.should_offload(il));

--- a/crates/models/mpt/src/lib.rs
+++ b/crates/models/mpt/src/lib.rs
@@ -123,7 +123,7 @@ impl KnownModel for Mpt {
 
             let f32_size = std::mem::size_of::<f32>();
 
-            let mut gf = ggml::ComputationGraph::new();
+            let mut gf = ctx0.create_compute_graph();
             for il in 0..n_layer {
                 // attention uses first scratch buffer
                 ctx0.use_scratch(builder.get_scratch(0));

--- a/crates/models/mpt/src/lib.rs
+++ b/crates/models/mpt/src/lib.rs
@@ -129,10 +129,7 @@ impl KnownModel for Mpt {
                 ctx0.use_scratch(builder.get_scratch(0));
 
                 let mut current = ctx0.op_norm(&input_layer);
-                current = ctx0.op_mul(
-                    &ctx0.op_repeat(&self.layers[il].norm_1_weight, &current),
-                    &current,
-                );
+                current = ctx0.op_mul(&current, &self.layers[il].norm_1_weight);
 
                 current = ctx0.op_mul_mat(&self.layers[il].c_attn_wqkv_weight, &current);
 
@@ -222,10 +219,7 @@ impl KnownModel for Mpt {
                 ctx0.use_scratch(builder.get_scratch(1));
 
                 current = ctx0.op_norm(&input_layer);
-                current = ctx0.op_mul(
-                    &ctx0.op_repeat(&self.layers[il].norm_2_weight, &current),
-                    &current,
-                );
+                current = ctx0.op_mul(&current, &self.layers[il].norm_2_weight);
 
                 current = ctx0.op_mul_mat(&self.layers[il].ffn_up_proj, &current);
 
@@ -242,7 +236,7 @@ impl KnownModel for Mpt {
 
             // norm
             input_layer = ctx0.op_norm(&input_layer);
-            input_layer = ctx0.op_mul(&ctx0.op_repeat(&self.norm, &input_layer), &input_layer);
+            input_layer = ctx0.op_mul(&input_layer, &self.norm);
 
             let embeddings_tensor: ggml::Tensor = input_layer.share();
 

--- a/doc/acceleration-support.md
+++ b/doc/acceleration-support.md
@@ -40,7 +40,7 @@ While specific accelerators only support certain model architectures, some unmar
 | MPT               | ❌       | ❌        | ❌      |
 | Falcon            | ❌       | ❌        | ❌      |
 | GPT-NeoX          | ❌       | ❌        | ❌      |
-| GPT-J             | ❌       | ❌        | ❌      |
+| GPT-J             | ✅       | ❌        | ❌      |
 | GPT-2             | ❌       | ❌        | ❌      |
 | BLOOM             | ❌       | ❌        | ❌      |
 


### PR DESCRIPTION
Removes the `op_repeat` ggml operation and replaces it with broadcasting. 

This should enable the gpu acceleration of: `gpt2`, `gptj`, `gptneox` and `falcon`

Also fixes: https://github.com/rustformers/llm/issues/391