### PR TITLE
fix(deps): remove pinned `half` dependency

### DIFF
--- a/crates/llm-base/Cargo.toml
+++ b/crates/llm-base/Cargo.toml
@@ -21,7 +21,7 @@ thiserror = { workspace = true }
 partial_sort = "0.2.0"
 serde_bytes = "0.11"
 memmap2 = { workspace = true }
-half = "=2.2.1"
+half = "2"
 tokenizers = {version="0.13.3", default-features=false, features=["onig"]}
 regex = "1.8"
 tracing = { workspace = true }


### PR DESCRIPTION
This commit removes the pinned version of the `half` crate, allowing consumers to resolve to a version of `half` that is compatible with other dependencies in the project.

I'm not sure if pinning to this exact version was intended — happy to close if this causes unintended behavior.

Thanks!