### PR TITLE
Add the ability to quantize into k-quants

### DIFF
--- a/binaries/llm-cli/src/cli_args.rs
+++ b/binaries/llm-cli/src/cli_args.rs
@@ -7,7 +7,7 @@ use std::{
 use clap::{Parser, ValueEnum};
 use color_eyre::eyre::{self, WrapErr};
 use llm::{
-    ggml_format, samplers::build_sampler, ElementType, InferenceParameters, InferenceSessionConfig,
+    ggml_format, samplers::build_sampler, InferenceParameters, InferenceSessionConfig,
     InvalidTokenBias, LoadProgress, Model, ModelKVMemoryType, ModelParameters, RoPEOverrides,
     TokenBias, TokenId, TokenizerSource,
 };
@@ -693,15 +693,36 @@ pub enum QuantizationTarget {
     Q5_1,
     /// Quantized 8-bit (type 0).
     Q8_0,
+    #[allow(non_camel_case_types)]
+    /// Quantized 2-bit (K-Type) ~2.5625 bits per weight.
+    Q2_K,
+    #[allow(non_camel_case_types)]
+    /// Quantized 3-bit (K-Type) ~3.4375 bits per weight.
+    Q3_K,
+    #[allow(non_camel_case_types)]
+    /// Quantized 4-bit K-Type) ~4.5 bits per weight.
+    Q4_K,
+    #[allow(non_camel_case_types)]
+    /// Quantized 5-bit (K-Type) ~5.5 bits per weight.
+    Q5_K,
+    #[allow(non_camel_case_types)]
+    /// Quantized 6-bit (K-Type) ~6.5625 bits per weight.
+    Q6_K,
 }
-impl From<QuantizationTarget> for ElementType {
+
+impl From<QuantizationTarget> for llm::QuantizationTarget {
     fn from(t: QuantizationTarget) -> Self {
         match t {
-            QuantizationTarget::Q4_0 => ElementType::Q4_0,
-            QuantizationTarget::Q4_1 => ElementType::Q4_1,
-            QuantizationTarget::Q5_0 => ElementType::Q5_0,
-            QuantizationTarget::Q5_1 => ElementType::Q5_1,
-            QuantizationTarget::Q8_0 => ElementType::Q8_0,
+            QuantizationTarget::Q4_0 => llm::QuantizationTarget::Q4_0,
+            QuantizationTarget::Q4_1 => llm::QuantizationTarget::Q4_1,
+            QuantizationTarget::Q5_0 => llm::QuantizationTarget::Q5_0,
+            QuantizationTarget::Q5_1 => llm::QuantizationTarget::Q5_1,
+            QuantizationTarget::Q8_0 => llm::QuantizationTarget::Q8_0,
+            QuantizationTarget::Q2_K => llm::QuantizationTarget::Q2_K,
+            QuantizationTarget::Q3_K => llm::QuantizationTarget::Q3_K,
+            QuantizationTarget::Q4_K => llm::QuantizationTarget::Q4_K,
+            QuantizationTarget::Q5_K => llm::QuantizationTarget::Q5_K,
+            QuantizationTarget::Q6_K => llm::QuantizationTarget::Q6_K,
         }
     }
 }

--- a/binaries/llm-cli/src/main.rs
+++ b/binaries/llm-cli/src/main.rs
@@ -257,6 +257,11 @@ fn quantize(args: &cli_args::Quantize) -> eyre::Result<()> {
                     } => log::info!(
                         "Finished quantization from {original_size} to {reduced_size} bytes ({history:?})"
                     ),
+                    QuantizeProgress::TensorFallback { name, dims, target, fallback } => {
+                        log::info!(
+                            "Falling back to {fallback} for tensor `{name}` ({dims:?} {target})", 
+                        )
+                    }
                 },
             )
             .wrap_err("failed to quantize model")

--- a/crates/ggml/src/lib.rs
+++ b/crates/ggml/src/lib.rs
@@ -130,6 +130,9 @@ pub const MAX_NAME_LENGTH: usize = sys::GGML_MAX_NAME as usize;
 /// Default epsilon to use for RMS computation.
 pub const DEFAULT_EPS: f32 = sys::llama::LLAMA_DEFAULT_RMS_EPS as f32;
 
+/// Block size used for the k-quantization algorithm.
+pub const K_QUANT_BLOCK_SIZE: usize = sys::QK_K as usize;
+
 /// Value overrides to use for RoPE.
 ///
 /// Formula: `theta_i = scale * base^(−2(i−1)/d), for i in [1, 2, ..., d/2]`
@@ -465,6 +468,46 @@ pub fn quantize_q5_1(src: &[f32], n_elements: usize, n_elements_0: usize) -> Qua
 /// is the first dimension of `src`.
 pub fn quantize_q8_0(src: &[f32], n_elements: usize, n_elements_0: usize) -> QuantizationResult {
     quantize_impl(src, n_elements, n_elements_0, sys::ggml_quantize_q8_0)
+}
+
+/// Quantizes `src` into `dst` using `q2_k` quantization.
+///
+/// You must ensure that `src.len() == n_elements`, and `n_elements_0`
+/// is the first dimension of `src`.
+pub fn quantize_q2_k(src: &[f32], n_elements: usize, n_elements_0: usize) -> QuantizationResult {
+    quantize_impl(src, n_elements, n_elements_0, sys::ggml_quantize_q2_K)
+}
+
+/// Quantizes `src` into `dst` using `q3_k` quantization.
+///
+/// You must ensure that `src.len() == n_elements`, and `n_elements_0`
+/// is the first dimension of `src`.
+pub fn quantize_q3_k(src: &[f32], n_elements: usize, n_elements_0: usize) -> QuantizationResult {
+    quantize_impl(src, n_elements, n_elements_0, sys::ggml_quantize_q3_K)
+}
+
+/// Quantizes `src` into `dst` using `q4_k` quantization.
+///
+/// You must ensure that `src.len() == n_elements`, and `n_elements_0`
+/// is the first dimension of `src`.
+pub fn quantize_q4_k(src: &[f32], n_elements: usize, n_elements_0: usize) -> QuantizationResult {
+    quantize_impl(src, n_elements, n_elements_0, sys::ggml_quantize_q4_K)
+}
+
+/// Quantizes `src` into `dst` using `q5_k` quantization.
+///
+/// You must ensure that `src.len() == n_elements`, and `n_elements_0`
+/// is the first dimension of `src`.
+pub fn quantize_q5_k(src: &[f32], n_elements: usize, n_elements_0: usize) -> QuantizationResult {
+    quantize_impl(src, n_elements, n_elements_0, sys::ggml_quantize_q5_K)
+}
+
+/// Quantizes `src` into `dst` using `q6_k` quantization.
+///
+/// You must ensure that `src.len() == n_elements`, and `n_elements_0`
+/// is the first dimension of `src`.
+pub fn quantize_q6_k(src: &[f32], n_elements: usize, n_elements_0: usize) -> QuantizationResult {
+    quantize_impl(src, n_elements, n_elements_0, sys::ggml_quantize_q6_K)
 }
 
 fn quantize_impl(

--- a/crates/llm-base/src/lib.rs
+++ b/crates/llm-base/src/lib.rs
@@ -36,7 +36,7 @@ pub use loader::{
 pub use lora::{LoraAdapter, LoraParameters};
 pub use memmap2::Mmap;
 pub use model::{Hyperparameters, KnownModel, Model, ModelParameters, OutputRequest};
-pub use quantize::{quantize, QuantizeError, QuantizeProgress};
+pub use quantize::{quantize, QuantizationTarget, QuantizeError, QuantizeProgress};
 pub use regex::Regex;
 pub use tokenizer::{
     InvalidTokenBias, Prompt, TokenBias, TokenId, TokenizationError, Tokenizer, TokenizerLoadError,

--- a/crates/llm-base/src/quantize.rs
+++ b/crates/llm-base/src/quantize.rs
@@ -447,38 +447,7 @@ impl<F: Fn(QuantizeProgress), H: Hyperparameters, R: BufRead + Seek> SaveHandler
                 _ => unreachable!(),
             };
 
-            let result = match target {
-                QuantizationTarget::Q4_0 => {
-                    ggml::quantize_q4_0(&data_f32, tensor.n_elements, tensor.dims[0])
-                }
-                QuantizationTarget::Q4_1 => {
-                    ggml::quantize_q4_1(&data_f32, tensor.n_elements, tensor.dims[0])
-                }
-                QuantizationTarget::Q5_0 => {
-                    ggml::quantize_q5_0(&data_f32, tensor.n_elements, tensor.dims[0])
-                }
-                QuantizationTarget::Q5_1 => {
-                    ggml::quantize_q5_1(&data_f32, tensor.n_elements, tensor.dims[0])
-                }
-                QuantizationTarget::Q8_0 => {
-                    ggml::quantize_q8_0(&data_f32, tensor.n_elements, tensor.dims[0])
-                }
-                QuantizationTarget::Q2_K => {
-                    ggml::quantize_q2_k(&data_f32, tensor.n_elements, tensor.dims[0])
-                }
-                QuantizationTarget::Q3_K => {
-                    ggml::quantize_q3_k(&data_f32, tensor.n_elements, tensor.dims[0])
-                }
-                QuantizationTarget::Q4_K => {
-                    ggml::quantize_q4_k(&data_f32, tensor.n_elements, tensor.dims[0])
-                }
-                QuantizationTarget::Q5_K => {
-                    ggml::quantize_q5_k(&data_f32, tensor.n_elements, tensor.dims[0])
-                }
-                QuantizationTarget::Q6_K => {
-                    ggml::quantize_q6_k(&data_f32, tensor.n_elements, tensor.dims[0])
-                }
-            };
+            let result = ggml::quantize(target.into(), &data_f32, 0, tensor.n_elements, None);
             let new_data = result.output;
 
             let mut history_new = vec![];

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -85,8 +85,8 @@ pub use llm_base::{
     InferenceParameters, InferenceRequest, InferenceResponse, InferenceSession,
     InferenceSessionConfig, InferenceSnapshot, InferenceSnapshotRef, InferenceStats,
     InvalidTokenBias, KnownModel, LoadError, LoadProgress, Loader, Model, ModelKVMemoryType,
-    ModelParameters, OutputRequest, Prompt, QuantizeError, QuantizeProgress, RewindError,
-    SnapshotError, TokenBias, TokenId, TokenUtf8Buffer, TokenizationError, Tokenizer,
+    ModelParameters, OutputRequest, Prompt, QuantizationTarget, QuantizeError, QuantizeProgress,
+    RewindError, SnapshotError, TokenBias, TokenId, TokenUtf8Buffer, TokenizationError, Tokenizer,
     TokenizerSource,
 };
 


### PR DESCRIPTION
Closes https://github.com/rustformers/llm/issues/330.

Currently this doesn't implement the "upgrade" logic of the k-quants where certain layers get quantized in a higher level depending on the postfix (`S`,`M`,`L` ) of the quantization. Due to this `q2_k` and `q3_k` are currently not usable/produce gibberish.  