### PR TITLE
add `Tensor::is_contiguous`

### DIFF
--- a/crates/ggml/src/tensor.rs
+++ b/crates/ggml/src/tensor.rs
@@ -220,6 +220,11 @@ impl Tensor {
             sys::opencl::ggml_cl_free_data(self.ptr.as_ptr());
         }
     }
+
+    /// Returns true if this tensor is stored contiguously in memory
+    pub fn is_contiguous(&self) -> bool {
+        unsafe { sys::ggml_is_contiguous(self.ptr.as_ptr()) }
+    }
 }
 impl Tensor {
     fn with_alive_ctx<U>(&self, mut f: impl FnMut() -> U) -> U {


### PR DESCRIPTION
`Tensor::is_contiguous`: returns true if this tensor is stored contiguously in memory