### PR TITLE
Fix build on macos m1

### DIFF
--- a/crates/ggml/sys/build.rs
+++ b/crates/ggml/sys/build.rs
@@ -75,17 +75,11 @@ fn main() {
         }
         "aarch64" => {
             if compiler.is_like_clang() || compiler.is_like_gnu() {
-                if std::env::var("HOST") == std::env::var("TARGET") {
+                if target_os == "macos" {
+                    build.flag("-mcpu=apple-m1");
+                    build.flag("-mfpu=neon");
+                } else if std::env::var("HOST") == std::env::var("TARGET") {
                     build.flag("-mcpu=native");
-                } else {
-                    #[allow(clippy::single_match)]
-                    match target_os.as_str() {
-                        "macos" => {
-                            build.flag("-mcpu=apple-m1");
-                            build.flag("-mfpu=neon");
-                        }
-                        _ => {}
-                    }
                 }
                 build.flag("-pthread");
             }


### PR DESCRIPTION
During a build using Jenkins agent I got an error `-mcpu=native` is not available for clang