### PR TITLE
fix &'static lifetime warning

### DIFF
--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -114,7 +114,7 @@ macro_rules! define_models {
 
         impl ModelArchitecture {
             /// All available model architectures
-            pub const ALL: &[Self] = &[
+            pub const ALL: &'static [Self] = &[
                 $(
                     #[cfg(feature = $model_lowercase_str)]
                     Self::$model_pascalcase,


### PR DESCRIPTION
When building a project with 1.74.0-nightly `rustc` compiler, I receive a warning further described by this thread.
https://github.com/rust-lang/rust/issues/115010